### PR TITLE
never hide static dataset widget

### DIFF
--- a/src/app/mesh/qgsmeshlayerproperties.cpp
+++ b/src/app/mesh/qgsmeshlayerproperties.cpp
@@ -80,7 +80,6 @@ QgsMeshLayerProperties::QgsMeshLayerProperties( QgsMapLayer *lyr, QgsMapCanvas *
 
   connect( mTemporalReloadButton, &QPushButton::clicked, this, &QgsMeshLayerProperties::reloadTemporalProperties );
   connect( mTemporalDateTimeReference, &QDateTimeEdit::dateTimeChanged, this, &QgsMeshLayerProperties::onTimeReferenceChange );
-  connect( mTemporalStaticDatasetCheckBox, &QCheckBox::toggled, this, &QgsMeshLayerProperties::onStaticDatasetCheckBoxChanged );
   connect( mMeshLayer, &QgsMeshLayer::activeScalarDatasetGroupChanged, mStaticScalarWidget, &QgsMeshStaticDatasetWidget::setScalarDatasetGroup );
   connect( mMeshLayer, &QgsMeshLayer::activeVectorDatasetGroupChanged, mStaticScalarWidget, &QgsMeshStaticDatasetWidget::setVectorDatasetGroup );
 
@@ -218,7 +217,6 @@ void QgsMeshLayerProperties::syncToLayer()
     mComboBoxTemporalDatasetMatchingMethod->findData( temporalProperties->matchingMethod() ) );
 
   mStaticScalarWidget->syncToLayer();
-  mStaticScalarWidget->setVisible( !mMeshLayer->temporalProperties()->isActive() );
   mTemporalStaticDatasetCheckBox->setChecked( !mMeshLayer->temporalProperties()->isActive() );
 }
 
@@ -462,9 +460,4 @@ void QgsMeshLayerProperties::onTimeReferenceChange()
   const QgsDateTimeRange &timeExtent = mMeshLayer->dataProvider()->temporalCapabilities()->timeExtent( mTemporalDateTimeReference->dateTime() );
   mTemporalDateTimeStart->setDateTime( timeExtent.begin() );
   mTemporalDateTimeEnd->setDateTime( timeExtent.end() );
-}
-
-void QgsMeshLayerProperties::onStaticDatasetCheckBoxChanged()
-{
-  mStaticScalarWidget->setVisible( mTemporalStaticDatasetCheckBox->isChecked() );
 }

--- a/src/app/mesh/qgsmeshlayerproperties.h
+++ b/src/app/mesh/qgsmeshlayerproperties.h
@@ -74,7 +74,6 @@ class APP_EXPORT QgsMeshLayerProperties : public QgsOptionsDialogBase, private U
 
     void onTimeReferenceChange();
 
-    void onStaticDatasetCheckBoxChanged();
   private:
     //! Pointer to the mesh styling widget
     QgsRendererMeshPropertiesWidget *mRendererMeshPropertiesWidget = nullptr;

--- a/src/core/mesh/qgsmeshlayer.cpp
+++ b/src/core/mesh/qgsmeshlayer.cpp
@@ -419,7 +419,6 @@ QgsMeshDatasetValue QgsMeshLayer::dataset1dValue( const QgsMeshDatasetIndex &ind
     }
   }
 
-
   return value;
 }
 

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -342,20 +342,32 @@ border-radius: 2px;</string>
                 <widget class="QgsMeshDatasetGroupTreeWidget" name="mDatasetGroupTreeWidget" native="true"/>
                </item>
                <item>
-                <widget class="QCheckBox" name="mTemporalStaticDatasetCheckBox">
-                 <property name="text">
+                <widget class="QGroupBox" name="groupBox">
+                 <property name="title">
                   <string>Static Dataset</string>
                  </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsMeshStaticDatasetWidget" name="mStaticScalarWidget" native="true">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_7">
+                  <item>
+                   <widget class="QgsMeshStaticDatasetWidget" name="mStaticScalarWidget" native="true">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QCheckBox" name="mTemporalStaticDatasetCheckBox">
+                    <property name="toolTip">
+                     <string>Static dataset even if the temporal navigation is on</string>
+                    </property>
+                    <property name="text">
+                     <string>Force Static Dataset with Temporal Navigation</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
                 </widget>
                </item>
                <item>


### PR DESCRIPTION
The new temporal framework led to the concept of static dataset for mesh layer, that is the dataset that is displayed if the temporal navigation is off or if the mesh layer is set to "Static Dataset".

Before, the possibility to set the map canvas with temporal navigation off, the choice of the dataset (with comboboxes) was possible only if the checkbox "Static dataset" was checked in the mesh layer properties widget.
Furthermore, the default QQIS map canvas is set with temporal navigation off. So after creating a new document and loading a mesh layer, it is the static dataset that is displayed even if the mesh layer is not forced to be static.
So, now, hiding the static dataset comboboxes has fewer sens.
With this PR those comboboxes are not hidden anymore.

![image](https://user-images.githubusercontent.com/7416892/83517926-c0d68780-a4a7-11ea-99c2-ae1c9fe73076.png)
