### PR TITLE
virtual dataset groups

### DIFF
--- a/external/mdal/api/mdal.h
+++ b/external/mdal/api/mdal.h
@@ -534,6 +534,11 @@ MDAL_EXPORT void MDAL_G_closeEditMode( MDAL_DatasetGroupH group );
 MDAL_EXPORT const char *MDAL_G_referenceTime( MDAL_DatasetGroupH group );
 
 /**
+ * Sets reference time for dataset group expressed in date with ISO8601 format
+ */
+MDAL_EXPORT void MDAL_G_setReferenceTime( MDAL_DatasetGroupH group, const char *referenceTimeISO8601 );
+
+/**
  * Returns whether the dataset group is temporal, i.e. has time-related datasets
  *
  * \since MDAL 0.6.0

--- a/external/mdal/mdal.cpp
+++ b/external/mdal/mdal.cpp
@@ -21,7 +21,7 @@ static const char *EMPTY_STR = "";
 
 const char *MDAL_Version()
 {
-  return "0.6.90";
+  return "0.6.91";
 }
 
 MDAL_Status MDAL_LastStatus()
@@ -872,6 +872,18 @@ const char *MDAL_G_referenceTime( MDAL_DatasetGroupH group )
   }
   MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
   return _return_str( g->referenceTime().toStandardCalendarISO8601() );
+}
+
+void MDAL_G_setReferenceTime( MDAL_DatasetGroupH group, const char *referenceTimeISO8601 )
+{
+  if ( !group )
+  {
+    MDAL::Log::error( MDAL_Status::Err_IncompatibleDataset, "Dataset Group is not valid (null)" );
+    return;
+  }
+  MDAL::DatasetGroup *g = static_cast< MDAL::DatasetGroup * >( group );
+  const std::string datetime( referenceTimeISO8601 );
+  g->setReferenceTime( MDAL::DateTime( datetime ) );
 }
 
 void MDAL_G_setMetadata( MDAL_DatasetGroupH group, const char *key, const char *val )

--- a/external/mdal/mdal_datetime.cpp
+++ b/external/mdal/mdal_datetime.cpp
@@ -49,6 +49,37 @@ MDAL::DateTime::DateTime( double value, Epoch epoch ):  mValid( true )
   }
 }
 
+MDAL::DateTime::DateTime( const std::string &fromISO8601 )
+{
+  std::vector<std::string> splitedDateTime = split( fromISO8601, 'T' );
+
+  if ( splitedDateTime.size() != 2 )
+    return;
+  //parse date
+  std::vector<std::string> splitedDate = split( splitedDateTime.at( 0 ), '-' );
+  if ( splitedDate.size() != 3 )
+    return;
+
+  //parse time
+  splitedDateTime[1] = replace( splitedDateTime.at( 1 ), "Z", "", ContainsBehaviour::CaseInsensitive );
+  std::vector<std::string> splitedTime = split( splitedDateTime.at( 1 ), ':' );
+  if ( splitedTime.size() < 2 || splitedTime.size() > 3 )
+    return;
+
+  DateTimeValues dateTimeValues;
+  dateTimeValues.year = toInt( splitedDate[0] );
+  dateTimeValues.month = toInt( splitedDate[1] );
+  dateTimeValues.day = toInt( splitedDate[2] );
+  dateTimeValues.hours = toInt( splitedTime[0] );
+  dateTimeValues.minutes = toInt( splitedTime[1] );
+  if ( splitedTime.size() == 3 )
+    dateTimeValues.seconds = toDouble( splitedTime[2] );
+  else
+    dateTimeValues.seconds = 0.0;
+
+  setWithGregorianCalendarDate( dateTimeValues );
+}
+
 std::string MDAL::DateTime::toStandardCalendarISO8601() const
 {
   if ( mValid )

--- a/external/mdal/mdal_datetime.hpp
+++ b/external/mdal/mdal_datetime.hpp
@@ -67,6 +67,9 @@ namespace MDAL
       //! Constructor with Julian day or Unix Epoch
       DateTime( double value, Epoch epoch );
 
+      //! Constructor with ISO 8601 string
+      DateTime( const std::string &fromISO8601 );
+
       //! Returns a string with the date/time expressed in Greogrian proleptic calendar with ISO8601 format (local time zone)
       //! Do not support negative year
       std::string toStandardCalendarISO8601() const;

--- a/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
+++ b/python/analysis/auto_generated/mesh/qgsmeshcalculator.sip.in
@@ -131,16 +131,19 @@ Creates calculator with geometry mask
 
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputGroupName,
-                       double startTime,
-                       double endTime,
                        const QgsRectangle &outputExtent,
-                       QgsMeshLayer *layer );
+                       const QgsMeshDatasetGroup::Type &destination,
+                       QgsMeshLayer *layer,
+                       double startTime,
+                       double endTime );
 %Docstring
-Creates calculator with bounding box (rectangular) mask, store the result in the memory
+Creates calculator with bounding box (rectangular) mask, store the result in ``destination`` (must be on memory or virtual),
+see QgsMeshCalculator.Destination
 
 :param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
 :param outputGroupName: output group name
 :param outputExtent: spatial filter defined by rectangle
+:param destination: destination of the calculation (memory or virtual)
 :param startTime: time filter defining the starting dataset
 :param endTime: time filter defining the ending dataset
 :param layer: mesh layer with dataset groups references in formulaString
@@ -150,16 +153,19 @@ Creates calculator with bounding box (rectangular) mask, store the result in the
 
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputGroupName,
-                       double startTime,
-                       double endTime,
                        const QgsGeometry &outputMask,
-                       QgsMeshLayer *layer );
+                       const QgsMeshDatasetGroup::Type &destination,
+                       QgsMeshLayer *layer,
+                       double startTime,
+                       double endTime );
 %Docstring
-Creates calculator with with geometry mask, store the result in the memory
+Creates calculator with with geometry mask, store the result in ``destination`` (must be on memory or virtual),
+see QgsMeshCalculator.Destination
 
 :param formulaString: formula/expression to evaluate. Consists of dataset group names, operators and numbers
 :param outputGroupName: output group name
 :param outputMask: spatial filter defined by geometry
+:param destination: destination of the calculation (memory or virtual)
 :param startTime: time filter defining the starting dataset
 :param endTime: time filter defining the ending dataset
 :param layer: mesh layer with dataset groups references in formulaString
@@ -167,10 +173,9 @@ Creates calculator with with geometry mask, store the result in the memory
 .. versionadded:: 3.16
 %End
 
-
     Result processCalculation( QgsFeedback *feedback = 0 );
 %Docstring
-Starts the calculation, writes new dataset group to file and adds it to the mesh layer
+Starts the calculation, creates new dataset group and adds it to the mesh layer
 
 :param feedback: The optional feedback argument for progress reporting and cancellation support
 

--- a/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshdataset.sip.in
@@ -12,7 +12,6 @@
 
 
 
-
 class QgsMeshDatasetIndex
 {
 %Docstring
@@ -449,12 +448,10 @@ Returns whether dataset group has vector data
 Returns whether dataset group has scalar data
 %End
 
-
     bool isTemporal() const;
 %Docstring
 Returns whether the dataset group is temporal (contains time-related dataset)
 %End
-
 
     DataType dataType() const;
 %Docstring
@@ -558,6 +555,213 @@ Returns maximum number of vertical levels for 3d stacked meshes
 };
 
 
+class QgsMeshDataset
+{
+%Docstring
+
+Abstract class that represents a dataset
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsmeshdataset.h"
+%End
+  public:
+    QgsMeshDataset();
+%Docstring
+Constructor
+%End
+
+    virtual ~QgsMeshDataset();
+
+    virtual QgsMeshDatasetValue datasetValue( int valueIndex ) const = 0;
+%Docstring
+Returns the value with index ``valueIndex``
+%End
+
+    virtual QgsMeshDataBlock datasetValues( bool isScalar, int valueIndex, int count ) const = 0;
+%Docstring
+Returns ``count`` values from ``valueIndex``
+%End
+
+    virtual QgsMeshDataBlock areFacesActive( int faceIndex, int count ) const = 0;
+%Docstring
+Returns whether faces are active
+%End
+
+    virtual bool isActive( int faceIndex ) const = 0;
+%Docstring
+Returns whether the face is active
+%End
+
+    virtual QgsMeshDatasetMetadata metadata() const = 0;
+%Docstring
+Returns the metadata of the dataset
+%End
+
+    virtual int valuesCount() const = 0;
+%Docstring
+Returns the values count
+%End
+};
+
+class QgsMeshDatasetGroup
+{
+%Docstring
+
+Abstract class that represents a dataset group
+
+.. versionadded:: 3.16
+%End
+
+%TypeHeaderCode
+#include "qgsmeshdataset.h"
+%End
+  public:
+
+    enum Type
+    {
+      None,
+      Persistent,
+      Memory,
+      Virtual,
+    };
+
+    QgsMeshDatasetGroup();
+%Docstring
+Default constructor
+%End
+    virtual ~QgsMeshDatasetGroup();
+
+    QgsMeshDatasetGroup( const QString &name );
+%Docstring
+Constructor with the ``name`` of the dataset group
+%End
+
+    QgsMeshDatasetGroup( const QString &name, QgsMeshDatasetGroupMetadata::DataType dataType );
+%Docstring
+Constructor with the ``name`` of the dataset group and the ``dataTYpe``
+%End
+
+    virtual void initialize() = 0;
+%Docstring
+Initialize the dataset group
+%End
+
+    QgsMeshDatasetGroupMetadata groupMetadata() const;
+%Docstring
+Returns the metadata of the dataset group
+%End
+
+    virtual QgsMeshDatasetMetadata datasetMetadata( int datasetIndex ) const = 0;
+%Docstring
+Returns the metadata of the dataset with index ``datasetIndex``
+%End
+
+    virtual int datasetCount() const = 0;
+%Docstring
+Returns the count of datasets in the group
+%End
+
+    virtual QgsMeshDataset *dataset( int index ) const = 0;
+%Docstring
+Returns the dataset with ``index``
+%End
+
+    virtual QgsMeshDatasetGroup::Type type() const = 0;
+%Docstring
+Returns the type of dataset group
+%End
+
+    double minimum() const;
+%Docstring
+Returns the minimum value of the whole dataset group
+%End
+
+    double maximum() const;
+%Docstring
+Returns the maximum value of the whole dataset group
+%End
+
+    void setMinimumMaximum( double min, double max );
+%Docstring
+Overrides the minimum and the maximum value of the whole dataset group
+%End
+
+    QString name() const;
+%Docstring
+Returns the name of the dataset group
+%End
+
+    void setName( const QString &name );
+%Docstring
+Sets the name of the dataset group
+%End
+
+    QgsMeshDatasetGroupMetadata::DataType dataType() const;
+%Docstring
+Returns the data type of the dataset group
+%End
+
+    void setDataType( const QgsMeshDatasetGroupMetadata::DataType &dataType );
+%Docstring
+Sets the data type of the dataset group
+%End
+
+    void addExtraMetadata( QString key, QString value );
+%Docstring
+Adds extra metadata to the group
+%End
+    QMap<QString, QString> extraMetadata() const;
+%Docstring
+Returns all the extra metadata of the group
+%End
+
+    bool isScalar() const;
+%Docstring
+Returns whether the group contain scalar values
+%End
+
+    void setIsScalar( bool isScalar );
+%Docstring
+Sets whether the group contain scalar values
+%End
+
+    bool checkValueCountPerDataset( int count ) const;
+%Docstring
+Returns whether all the datasets contain ``count`` values
+%End
+
+    void calculateStatistic();
+%Docstring
+Calculates the statictics (minimum and maximum)
+%End
+
+    virtual QStringList datasetGroupNamesDependentOn() const;
+%Docstring
+Returns the dataset group variable name which this dataset group depends on
+%End
+
+    virtual QDomElement writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const = 0;
+%Docstring
+Write dataset group information in a DOM element
+%End
+
+    virtual QString description() const;
+%Docstring
+Returns some information about the dataset group
+%End
+
+    void setReferenceTime( const QDateTime &referenceTime );
+
+  protected:
+
+
+};
+
+
+
 class QgsMeshDatasetGroupTreeItem
 {
 %Docstring
@@ -578,6 +782,8 @@ Wind speed
 Minimum
 Maximum
 
+Tree items handle also the dependencies between dataset groups represented by these items
+
 .. versionadded:: 3.14
 %End
 
@@ -586,27 +792,20 @@ Maximum
 %End
   public:
 
-    enum StorageType
-    {
-      None,
-      File,
-      Memory,
-      OnTheFly
-    };
-
     QgsMeshDatasetGroupTreeItem();
 %Docstring
 Constructor for an empty dataset group tree item
 %End
 
     QgsMeshDatasetGroupTreeItem( const QString &defaultName,
-                                 const QString &providerName,
+                                 const QString &sourceName,
                                  bool isVector,
                                  int index );
 %Docstring
 Constructor
 
 :param defaultName: the name that will be used to display the item if iot not overrides (:py:func:`setName`)
+:param sourceName: the name used by the source (provider, dataset group store,...)
 :param isVector: whether the dataset group is a vector dataset group
 :param index: index of the dataset group
 %End
@@ -756,26 +955,49 @@ Sets whether the item is enabled, that is if it is displayed in view
 :return: the default name
 %End
 
-    QgsMeshDatasetGroupTreeItem::StorageType storageType() const;
+    QgsMeshDatasetGroup::Type datasetGroupType() const;
 %Docstring
 
-:return: where the dataset group is stored
+:return: the dataset group type
 
 .. versionadded:: 3.16
 %End
 
-    void setStorageType( QgsMeshDatasetGroupTreeItem::StorageType storageType );
+    QList<int> groupIndexDependencies() const;
 %Docstring
-Sets where the dataset is stored
+Returns a list of group index corresponding to dataset group that depends on the dataset group represented by this item
 
-:param storeType: the type of storing
+:return: list of group index
+%End
+
+    QString description() const;
+%Docstring
+Returns description about the dataset group (URI, formula,...)
+
+.. versionadded:: 3.16
+%End
+
+    void setDatasetGroup( QgsMeshDatasetGroup *datasetGroup );
+%Docstring
+Set parameters of the item in accordance with the dataset group
+
+:param datasetGroup: pointer to the dataset group to accord with
+
+.. versionadded:: 3.16
+%End
+
+    void setPersistentDatasetGroup( const QString &uri );
+%Docstring
+Set parameters of the item in accordance with the persistent dataset group with ``uri``
+
+:param uri: uri of the persistant dataset group
 
 .. versionadded:: 3.16
 %End
 
     QDomElement writeXml( QDomDocument &doc, const QgsReadWriteContext &context );
 %Docstring
-Write the item and its children in a DOM document
+Writes the item and its children in a DOM document
 
 :param doc: the DOM document
 :param context: writing context (e.g. for conversion between relative and absolute paths)
@@ -784,7 +1006,6 @@ Write the item and its children in a DOM document
 %End
 
 };
-
 
 /************************************************************************
  * This file has been generated automatically from                      *

--- a/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
+++ b/python/core/auto_generated/mesh/qgsmeshlayer.sip.in
@@ -144,8 +144,6 @@ QgsMeshLayer cannot be copied.
 
     virtual QStringList subLayers() const;
 
-    virtual bool isTemporary() const;
-
 
     QString providerType() const;
 %Docstring
@@ -477,11 +475,10 @@ Returns the value of 1D mesh dataset defined on edge that are in the search area
 .. versionadded:: 3.14
 %End
 
-
     QgsMeshDatasetIndex datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const;
 %Docstring
 Returns dataset index from datasets group depending on the time range.
-If the temporal properties is not active, returns invalid dataset index
+If the temporal properties is not active, returns invalid dataset index. This method is used for rendering mesh layer.
 
 :param timeRange: the time range
 
@@ -499,6 +496,29 @@ If the temporal properties is not active, returns invalid dataset index
 
 
 .. versionadded:: 3.14
+%End
+
+    QgsMeshDatasetIndex datasetIndexAtRelativeTime( const QgsInterval &relativeTime, int datasetGroupIndex ) const;
+%Docstring
+Returns dataset index from datasets group depending on the relative time from the layer reference time.
+Dataset index is valid even the temporal properties is inactive. This method is used for calculation on mesh layer.
+
+:param relativeTime: the relative from the mesh layer reference time
+
+:return: dataset index
+
+.. note::
+
+   the returned dataset index depends on the matching method, see :py:func:`~QgsMeshLayer.setTemporalMatchingMethod`
+
+
+.. note::
+
+   indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)
+   In the layer scope, those indexes are different from the data provider indexes.
+
+
+.. versionadded:: 3.16
 %End
 
     QgsMeshDatasetIndex activeScalarDatasetAtTime( const QgsDateTimeRange &timeRange ) const;
@@ -636,6 +656,13 @@ Returns the first valid time step of the dataset groups, invalid QgInterval if n
 %End
 
     QgsInterval datasetRelativeTime( const QgsMeshDatasetIndex &index );
+%Docstring
+Returns the relative time of the dataset from the reference time of its group
+
+.. versionadded:: 3.16
+%End
+
+    qint64 datasetRelativeTimeInMilliseconds( const QgsMeshDatasetIndex &index );
 %Docstring
 Returns the relative time (in milliseconds) of the dataset from the reference time of its group
 

--- a/python/core/auto_generated/qgsapplication.sip.in
+++ b/python/core/auto_generated/qgsapplication.sip.in
@@ -870,6 +870,7 @@ differently across work stations.
 .. versionadded:: 3.14
 %End
 
+
     static QString nullRepresentation();
 %Docstring
 This string is used to represent the value `NULL` throughout QGIS.

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -221,6 +221,7 @@ SET(QGIS_ANALYSIS_SRCS
   mesh/qgsmeshcalculator.cpp
   mesh/qgsmeshcalcutils.cpp
   mesh/qgsmeshcontours.cpp
+  mesh/qgsmeshvirtualdatasetgroup.cpp
 
   network/qgsgraph.cpp
   network/qgsgraphbuilder.cpp
@@ -291,6 +292,7 @@ SET(QGIS_ANALYSIS_HDRS
   mesh/qgsmeshcalculator.h
   mesh/qgsmeshcalcutils.h
   mesh/qgsmeshcontours.h
+  mesh/qgsmeshvirtualdatasetgroup.h
 
   network/qgsgraph.h
   network/qgsgraphanalyzer.h

--- a/src/analysis/mesh/qgsmeshcalcnode.cpp
+++ b/src/analysis/mesh/qgsmeshcalcnode.cpp
@@ -231,4 +231,48 @@ QgsMeshCalcNode *QgsMeshCalcNode::parseMeshCalcString( const QString &str, QStri
   return localParseMeshCalcString( str, parserErrorMsg );
 }
 
+bool QgsMeshCalcNode::isNonTemporal() const
+{
+  if ( mType == tNoData || mType == tNumber )
+    return true;
+
+  if ( mType == tDatasetGroupRef )
+    return false;
+
+  switch ( mOperator )
+  {
+    case QgsMeshCalcNode::opPLUS:
+    case QgsMeshCalcNode::opMINUS:
+    case QgsMeshCalcNode::opMUL:
+    case QgsMeshCalcNode::opDIV:
+    case QgsMeshCalcNode::opPOW:
+    case QgsMeshCalcNode::opEQ:
+    case QgsMeshCalcNode::opNE:
+    case QgsMeshCalcNode::opGT:
+    case QgsMeshCalcNode::opLT:
+    case QgsMeshCalcNode::opGE:
+    case QgsMeshCalcNode::opLE:
+    case QgsMeshCalcNode::opAND:
+    case QgsMeshCalcNode::opOR:
+    case QgsMeshCalcNode::opNOT:
+    case QgsMeshCalcNode::opIF:
+    case QgsMeshCalcNode::opSIGN:
+    case QgsMeshCalcNode::opMIN:
+    case QgsMeshCalcNode::opMAX:
+    case QgsMeshCalcNode::opABS:
+      return ( mLeft && mLeft->isNonTemporal() ) &&
+             ( mRight && mRight->isNonTemporal() );
+      break;
+    case QgsMeshCalcNode::opSUM_AGGR:
+    case QgsMeshCalcNode::opMAX_AGGR:
+    case QgsMeshCalcNode::opMIN_AGGR:
+    case QgsMeshCalcNode::opAVG_AGGR:
+    case QgsMeshCalcNode::opNONE:
+      return true;
+      break;
+  }
+
+  return true;
+}
+
 ///@endcond

--- a/src/analysis/mesh/qgsmeshcalcnode.h
+++ b/src/analysis/mesh/qgsmeshcalcnode.h
@@ -145,6 +145,12 @@ class ANALYSIS_EXPORT QgsMeshCalcNode
      */
     static QgsMeshCalcNode *parseMeshCalcString( const QString &str, QString &parserErrorMsg );
 
+    /**
+     * Returns whether the calculation wil leads to a non temporal dataset group result
+     * \returns true if the result will be non temporal
+     */
+    bool isNonTemporal() const;
+
   private:
     Q_DISABLE_COPY( QgsMeshCalcNode )
 

--- a/src/analysis/mesh/qgsmeshcalculator.h
+++ b/src/analysis/mesh/qgsmeshcalculator.h
@@ -143,10 +143,12 @@ class ANALYSIS_EXPORT QgsMeshCalculator
                        QgsMeshLayer *layer );
 
     /**
-     * Creates calculator with bounding box (rectangular) mask, store the result in the memory
+     * Creates calculator with bounding box (rectangular) mask, store the result in \a destination (must be on memory or virtual),
+     * see QgsMeshCalculator::Destination
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
      * \param outputGroupName output group name
      * \param outputExtent spatial filter defined by rectangle
+     * \param destination destination of the calculation (memory or virtual)
      * \param startTime time filter defining the starting dataset
      * \param endTime time filter defining the ending dataset
      * \param layer mesh layer with dataset groups references in formulaString
@@ -155,16 +157,19 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      */
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputGroupName,
-                       double startTime,
-                       double endTime,
                        const QgsRectangle &outputExtent,
-                       QgsMeshLayer *layer );
+                       const QgsMeshDatasetGroup::Type &destination,
+                       QgsMeshLayer *layer,
+                       double startTime,
+                       double endTime );
 
     /**
-     * Creates calculator with with geometry mask, store the result in the memory
+     * Creates calculator with with geometry mask, store the result in \a destination (must be on memory or virtual),
+     *  see QgsMeshCalculator::Destination
      * \param formulaString formula/expression to evaluate. Consists of dataset group names, operators and numbers
      * \param outputGroupName output group name
      * \param outputMask spatial filter defined by geometry
+     * \param destination destination of the calculation (memory or virtual)
      * \param startTime time filter defining the starting dataset
      * \param endTime time filter defining the ending dataset
      * \param layer mesh layer with dataset groups references in formulaString
@@ -173,14 +178,14 @@ class ANALYSIS_EXPORT QgsMeshCalculator
      */
     QgsMeshCalculator( const QString &formulaString,
                        const QString &outputGroupName,
-                       double startTime,
-                       double endTime,
                        const QgsGeometry &outputMask,
-                       QgsMeshLayer *layer );
-
+                       const QgsMeshDatasetGroup::Type &destination,
+                       QgsMeshLayer *layer,
+                       double startTime,
+                       double endTime );
 
     /**
-     * Starts the calculation, writes new dataset group to file and adds it to the mesh layer
+     * Starts the calculation, creates new dataset group and adds it to the mesh layer
      * \param feedback The optional feedback argument for progress reporting and cancellation support
      * \returns QgsMeshCalculator::Success in case of success
      */
@@ -220,9 +225,9 @@ class ANALYSIS_EXPORT QgsMeshCalculator
     QgsRectangle mOutputExtent;
     QgsGeometry mOutputMask;
     bool mUseMask = false;
+    QgsMeshDatasetGroup::Type mDestination;
     double mStartTime = 0.0;
     double mEndTime = 0.0;
-    bool mResultInMemory = false;
     QgsMeshLayer *mMeshLayer = nullptr;
 };
 

--- a/src/analysis/mesh/qgsmeshcalcutils.cpp
+++ b/src/analysis/mesh/qgsmeshcalcutils.cpp
@@ -31,14 +31,13 @@ const double D_TRUE = 1.0;
 const double D_FALSE = 0.0;
 const double D_NODATA = std::numeric_limits<double>::quiet_NaN();
 
-std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QString &datasetGroupName ) const
+std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QString &datasetGroupName, const QgsInterval &relativeTime ) const
 {
-  const auto dp = mMeshLayer->dataProvider();
   std::shared_ptr<QgsMeshMemoryDatasetGroup> grp;
   const QList<int> &indexes = mMeshLayer->datasetGroupsIndexes();
   for ( int groupIndex : indexes )
   {
-    const auto meta = mMeshLayer->datasetGroupMetadata( groupIndex );
+    const QgsMeshDatasetGroupMetadata meta = mMeshLayer->datasetGroupMetadata( groupIndex );
     const QString name = meta.name();
     if ( name == datasetGroupName )
     {
@@ -53,104 +52,122 @@ std::shared_ptr<QgsMeshMemoryDatasetGroup> QgsMeshCalcUtils::create( const QStri
       grp->setMinimumMaximum( meta.minimum(), meta.maximum() );
       grp->setName( meta.name() );
 
-      int nativeCount = ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
-      int resultCount = ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
-
-      for ( int datasetIndex = 0; datasetIndex < mMeshLayer->datasetCount( groupIndex ); ++datasetIndex )
+      if ( !relativeTime.isValid() )
       {
-        const QgsMeshDatasetIndex index( groupIndex, datasetIndex );
-        const auto dsMeta = mMeshLayer->datasetMetadata( index );
-        std::shared_ptr<QgsMeshMemoryDataset> ds = create( grp->dataType() );
-        ds->maximum = dsMeta.maximum();
-        ds->minimum = dsMeta.minimum();
-        ds->time = dsMeta.time();
-        ds->valid = dsMeta.isValid();
-
-        // the function already averages volume datasets to face dataset values
-        QgsMeshDataBlock block = QgsMeshLayerUtils::datasetValues( mMeshLayer, index, 0, nativeCount );
-        // it is 2D memory datasets, so it shouldn't be invalid
-        Q_ASSERT( block.isValid() );
-        Q_ASSERT( block.count() == nativeCount );
-
-        // for data on faces, there could be request to interpolate the data to vertices
-        if ( ( meta.dataType() != QgsMeshDatasetGroupMetadata::DataOnVertices ) && ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices ) )
-        {
-          if ( grp->isScalar() )
-          {
-            QVector<double> data =
-              QgsMeshLayerUtils::interpolateFromFacesData(
-                block.values(),
-                nativeMesh(),
-                triangularMesh(),
-                nullptr,
-                QgsMeshRendererScalarSettings::NeighbourAverage
-              );
-            Q_ASSERT( data.size() == resultCount );
-            for ( int valueIndex = 0; valueIndex < resultCount; ++valueIndex )
-              ds->values[valueIndex] = QgsMeshDatasetValue( data[valueIndex] );
-          }
-          else
-          {
-            QVector<double> buf = block.values();
-            QVector<double> x( nativeCount );
-            QVector<double> y( nativeCount );
-            for ( int value_i = 0; value_i < nativeCount; ++value_i )
-            {
-              x[value_i] = buf[2 * value_i];
-              y[value_i] = buf[2 * value_i + 1];
-            }
-
-            QVector<double> dataX =
-              QgsMeshLayerUtils::interpolateFromFacesData(
-                x,
-                mMeshLayer->nativeMesh(),
-                mMeshLayer->triangularMesh(),
-                nullptr,
-                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataResamplingMethod()
-              );
-            Q_ASSERT( dataX.size() == resultCount );
-            QVector<double> dataY =
-              QgsMeshLayerUtils::interpolateFromFacesData(
-                y,
-                mMeshLayer->nativeMesh(),
-                mMeshLayer->triangularMesh(),
-                nullptr,
-                mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataResamplingMethod()
-              );
-
-            Q_ASSERT( dataY.size() == resultCount );
-
-            for ( int value_i = 0; value_i < resultCount; ++value_i )
-            {
-              ds->values[value_i] = QgsMeshDatasetValue( dataX[value_i], dataY[value_i] );
-            }
-          }
-        }
-        else
-        {
-          for ( int value_i = 0; value_i < resultCount; ++value_i )
-            ds->values[value_i] = block.value( value_i );
-        }
-
-        if ( grp->dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices )
-        {
-          const QgsMeshDataBlock active = mMeshLayer->areFacesActive( index, 0, dp->faceCount() );
-          Q_ASSERT( active.count() == dp->faceCount() );
-          for ( int value_i = 0; value_i < dp->faceCount(); ++value_i )
-            ds->active[value_i] = active.active( value_i );
-        }
-        grp->addDataset( ds );
+        for ( int index = 0; index < mMeshLayer->datasetCount( groupIndex ); ++index )
+          grp->addDataset( create( QgsMeshDatasetIndex( groupIndex, index ) ) );
       }
+      else
+      {
+        QgsMeshDatasetIndex datasetIndex = mMeshLayer->datasetIndexAtRelativeTime( relativeTime, groupIndex );
+        if ( datasetIndex.isValid() )
+          grp->addDataset( create( datasetIndex ) );
+      }
+
 
       break;
     }
   }
+
   return grp;
 }
 
 std::shared_ptr<QgsMeshMemoryDataset> QgsMeshCalcUtils::create( const QgsMeshMemoryDatasetGroup &grp ) const
 {
   return create( grp.dataType() );
+}
+
+std::shared_ptr<QgsMeshMemoryDataset> QgsMeshCalcUtils::create( const QgsMeshDatasetIndex &datasetIndex ) const
+{
+  const QgsMeshDataProvider *dp = mMeshLayer->dataProvider();
+  int groupIndex = datasetIndex.group();
+  const auto meta = mMeshLayer->datasetGroupMetadata( groupIndex );
+
+  int nativeCount = ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
+  int resultCount = ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices ) ? dp->vertexCount() : dp->faceCount();
+
+  const QgsMeshDatasetMetadata dsMeta = mMeshLayer->datasetMetadata( datasetIndex );
+  std::shared_ptr<QgsMeshMemoryDataset> ds = create( mOutputType );
+  ds->maximum = dsMeta.maximum();
+  ds->minimum = dsMeta.minimum();
+  ds->time = dsMeta.time();
+  ds->valid = dsMeta.isValid();
+
+  // the function already averages volume datasets to face dataset values
+  QgsMeshDataBlock block = QgsMeshLayerUtils::datasetValues( mMeshLayer, datasetIndex, 0, nativeCount );
+  // it is 2D memory datasets, so it shouldn't be invalid
+  Q_ASSERT( block.isValid() );
+  Q_ASSERT( block.count() == nativeCount );
+
+  // for data on faces, there could be request to interpolate the data to vertices
+  if ( ( meta.dataType() != QgsMeshDatasetGroupMetadata::DataOnVertices ) && ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices ) )
+  {
+    if ( meta.isScalar() )
+    {
+      QVector<double> data =
+        QgsMeshLayerUtils::interpolateFromFacesData(
+          block.values(),
+          nativeMesh(),
+          triangularMesh(),
+          nullptr,
+          QgsMeshRendererScalarSettings::NeighbourAverage
+        );
+      Q_ASSERT( data.size() == resultCount );
+      for ( int valueIndex = 0; valueIndex < resultCount; ++valueIndex )
+        ds->values[valueIndex] = QgsMeshDatasetValue( data[valueIndex] );
+    }
+    else
+    {
+      QVector<double> buf = block.values();
+      QVector<double> x( nativeCount );
+      QVector<double> y( nativeCount );
+      for ( int value_i = 0; value_i < nativeCount; ++value_i )
+      {
+        x[value_i] = buf[2 * value_i];
+        y[value_i] = buf[2 * value_i + 1];
+      }
+
+      QVector<double> dataX =
+        QgsMeshLayerUtils::interpolateFromFacesData(
+          x,
+          mMeshLayer->nativeMesh(),
+          mMeshLayer->triangularMesh(),
+          nullptr,
+          mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataResamplingMethod()
+        );
+      Q_ASSERT( dataX.size() == resultCount );
+      QVector<double> dataY =
+        QgsMeshLayerUtils::interpolateFromFacesData(
+          y,
+          mMeshLayer->nativeMesh(),
+          mMeshLayer->triangularMesh(),
+          nullptr,
+          mMeshLayer->rendererSettings().scalarSettings( groupIndex ).dataResamplingMethod()
+        );
+
+      Q_ASSERT( dataY.size() == resultCount );
+
+      for ( int value_i = 0; value_i < resultCount; ++value_i )
+      {
+        ds->values[value_i] = QgsMeshDatasetValue( dataX[value_i], dataY[value_i] );
+      }
+    }
+  }
+  else
+  {
+    for ( int value_i = 0; value_i < resultCount; ++value_i )
+      ds->values[value_i] = block.value( value_i );
+  }
+
+  if ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnVertices )
+  {
+    const QgsMeshDataBlock active = mMeshLayer->areFacesActive( datasetIndex, 0, dp->faceCount() );
+    Q_ASSERT( active.count() == dp->faceCount() );
+    for ( int value_i = 0; value_i < dp->faceCount(); ++value_i )
+      ds->active[value_i] = active.active( value_i );
+  }
+
+  return ds;
 }
 
 std::shared_ptr<QgsMeshMemoryDataset> QgsMeshCalcUtils::create( const QgsMeshDatasetGroupMetadata::DataType type ) const
@@ -208,8 +225,8 @@ QgsMeshCalcUtils:: QgsMeshCalcUtils( QgsMeshLayer *layer,
   // Now populate used times and check that all datasets do have some times
   // OR just one time (== one output)
   bool timesPopulated = false;
-  const auto vals = mDatasetGroupMap.values();
-  for ( const auto &ds : vals )
+  const QList<std::shared_ptr<QgsMeshMemoryDatasetGroup>> vals = mDatasetGroupMap.values();
+  for ( const std::shared_ptr<QgsMeshMemoryDatasetGroup> &ds : vals )
   {
     if ( ds->datasetCount() == 0 )
     {
@@ -269,13 +286,50 @@ QgsMeshCalcUtils:: QgsMeshCalcUtils( QgsMeshLayer *layer,
   }
 
   // check that all datasets are of the same type
-  for ( const auto &ds : vals )
+  for ( const std::shared_ptr<QgsMeshMemoryDatasetGroup> &ds : vals )
   {
     if ( ds->dataType() != mOutputType )
       return;
   }
 
   // All is valid!
+  mIsValid = true;
+}
+
+QgsMeshCalcUtils::QgsMeshCalcUtils( QgsMeshLayer *layer, const QStringList &usedGroupNames, const QgsInterval &relativeTime )
+  : mMeshLayer( layer )
+  , mIsValid( false )
+{
+  // Layer must be valid
+  if ( !mMeshLayer || !mMeshLayer->dataProvider() )
+    return;
+
+  // Resolve output type of the calculation
+  mOutputType = determineResultDataType( layer, usedGroupNames );
+
+  // Data on edges are not implemented
+  if ( mOutputType == QgsMeshDatasetGroupMetadata::DataOnEdges )
+    return;
+
+  // Support for meshes with edges are not implemented
+  if ( mMeshLayer->dataProvider()->contains( QgsMesh::ElementType::Edge ) )
+    return;
+
+  QgsInterval usedInterval = relativeTime;
+  if ( !usedInterval.isValid() )
+    usedInterval = QgsInterval( 0 );
+
+  for ( const QString &groupName : usedGroupNames )
+  {
+    std::shared_ptr<QgsMeshMemoryDatasetGroup> ds = create( groupName, relativeTime );
+    if ( !ds || ds->memoryDatasets.isEmpty() )
+      return;
+
+    mDatasetGroupMap.insert( groupName, ds );
+  }
+
+  mTimes.push_back( usedInterval.hours() );
+
   mIsValid = true;
 }
 
@@ -406,9 +460,9 @@ void QgsMeshCalcUtils::number( QgsMeshMemoryDatasetGroup &group1, double val ) c
 {
   Q_ASSERT( isValid() );
 
-  group1.memoryDatasets.clear();
+  group1.clearDatasets();
   std::shared_ptr<QgsMeshMemoryDataset> output = number( val, mTimes[0] );
-  group1.memoryDatasets.push_back( output );
+  group1.addDataset( output );
 }
 
 
@@ -654,8 +708,8 @@ void QgsMeshCalcUtils::funcAggr(
     // lets do activation purely on NODATA values as we did aggregation here
     activate( output );
 
-    group1.memoryDatasets.clear();
-    group1.memoryDatasets.push_back( output );
+    group1.clearDatasets();
+    group1.addDataset( output );
 
   }
   else
@@ -688,8 +742,8 @@ void QgsMeshCalcUtils::funcAggr(
       output->values[n] = res_val;
     }
 
-    group1.memoryDatasets.clear();
-    group1.memoryDatasets.push_back( output );
+    group1.clearDatasets();
+    group1.addDataset( output );
   }
 }
 
@@ -1171,16 +1225,16 @@ QgsMeshDatasetGroupMetadata::DataType QgsMeshCalcUtils::determineResultDataType(
   const QList<int> &groupIndexes = layer->datasetGroupsIndexes();
   for ( int groupId : groupIndexes )
   {
-    const auto meta = layer->datasetGroupMetadata( groupId );
+    const QgsMeshDatasetGroupMetadata meta = layer->datasetGroupMetadata( groupId );
     const QString name = meta.name();
     names[ name ] = groupId;
   }
-  for ( const auto &datasetGroupName : usedGroupNames )
+  for ( const QString &datasetGroupName : usedGroupNames )
   {
     if ( names.contains( datasetGroupName ) )
     {
       int groupId = names.value( datasetGroupName );
-      const auto meta = layer->datasetGroupMetadata( groupId );
+      const QgsMeshDatasetGroupMetadata meta = layer->datasetGroupMetadata( groupId );
       if ( meta.dataType() == QgsMeshDatasetGroupMetadata::DataOnVertices )
       {
         return QgsMeshDatasetGroupMetadata::DataOnVertices;

--- a/src/analysis/mesh/qgsmeshcalcutils.h
+++ b/src/analysis/mesh/qgsmeshcalcutils.h
@@ -64,6 +64,21 @@ class ANALYSIS_EXPORT QgsMeshCalcUtils
                       double startTime,
                       double endTime );
 
+    /**
+     * Creates the utils and validates the input
+     *
+     * The constructor fetches dataset values from selected dataset corresponding to the relative time \a relativeTime
+     * (see QgsMeshLayer::datasetIndexAtRelativeTime() and creates memory datasets from them.
+     * There are only one dataset per group, selected with the matching method defined for the layer.
+     *
+     * \param layer mesh layer
+     * \param usedGroupNames dataset group's names that are used in the expression
+     * \param timeRange time range
+     */
+    QgsMeshCalcUtils( QgsMeshLayer *layer,
+                      const QStringList &usedGroupNames,
+                      const QgsInterval &relativeTime );
+
     //! Returns whether the input parameters are consistent and valid for given mesh layer
     bool isValid() const;
 
@@ -213,12 +228,17 @@ class ANALYSIS_EXPORT QgsMeshCalcUtils
      * memory dataset group. Returns NULLPTR if no such dataset group
      * exists. Resulting datasets are guaranteed to have the same mOutputType type
      */
-    std::shared_ptr<QgsMeshMemoryDatasetGroup> create( const QString &datasetGroupName ) const;
+    std::shared_ptr<QgsMeshMemoryDatasetGroup> create( const QString &datasetGroupName, const QgsInterval &relativeTime = QgsInterval() ) const;
 
     /**
      *  Creates dataset based on group. Initializes values and active based on group type.
      */
     std::shared_ptr<QgsMeshMemoryDataset> create( const QgsMeshMemoryDatasetGroup &grp ) const;
+
+    /**
+     *  Creates dataset based on group. Fill with values of corresponding dataset
+     */
+    std::shared_ptr<QgsMeshMemoryDataset> create( const QgsMeshDatasetIndex &datasetIndex ) const;
 
     /**
      *  Creates dataset with given type. Initializes values and active based on type.

--- a/src/analysis/mesh/qgsmeshvirtualdatasetgroup.cpp
+++ b/src/analysis/mesh/qgsmeshvirtualdatasetgroup.cpp
@@ -1,0 +1,181 @@
+/***************************************************************************
+                         qgsmeshvirtualdatasetgroup.cpp
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmeshvirtualdatasetgroup.h"
+#include "qgsmeshlayertemporalproperties.h"
+
+QgsMeshVirtualDatasetGroup::QgsMeshVirtualDatasetGroup(
+  const QString &name,
+  const QString &formulaString,
+  QgsMeshLayer *layer,
+  qint64 relativeStartTime,
+  qint64 relativeEndTime ):
+  QgsMeshDatasetGroup( name )
+  , mFormula( formulaString )
+  , mLayer( layer )
+  , mStartTime( relativeStartTime )
+  , mEndTime( relativeEndTime )
+{
+}
+
+void QgsMeshVirtualDatasetGroup::initialize()
+{
+  QString errMessage;
+  mCalcNode.reset( QgsMeshCalcNode::parseMeshCalcString( mFormula, errMessage ) );
+
+  if ( !mCalcNode || !mLayer )
+    return;
+
+  mDatasetGroupNameUsed = mCalcNode->usedDatasetGroupNames();
+  setDataType( QgsMeshCalcUtils::determineResultDataType( mLayer, mDatasetGroupNameUsed ) );
+
+  //populate used group indexes
+  QMap<QString, int> usedDatasetGroupindexes;
+  const QList<int> &indexes = mLayer->datasetGroupsIndexes();
+  for ( int i : indexes )
+  {
+    QString usedName = mLayer->datasetGroupMetadata( i ).name();
+    if ( mDatasetGroupNameUsed.contains( usedName ) )
+      usedDatasetGroupindexes[usedName] = i;
+  }
+
+  QSet<qint64> times;
+  if ( !mCalcNode->isNonTemporal() )
+  {
+    //populate dataset index with time;
+    const QList<int> &usedIndexes = usedDatasetGroupindexes.values();
+    for ( int groupIndex : usedIndexes )
+    {
+      int dsCount = mLayer->datasetCount( groupIndex );
+      if ( dsCount == 0 )
+        return;
+
+      if ( dsCount == 1 ) //non temporal dataset group
+        continue;
+      for ( int i = 0; i < dsCount; i++ )
+      {
+        qint64 time = mLayer->datasetRelativeTimeInMilliseconds( QgsMeshDatasetIndex( groupIndex, i ) );
+        if ( time != INVALID_MESHLAYER_TIME )
+          times.insert( time );
+      }
+    }
+  }
+
+  if ( times.isEmpty() )
+    times.insert( 0 );
+
+  mDatasetTimes = times.toList();
+  std::sort( mDatasetTimes.begin(), mDatasetTimes.end() );
+
+  mDatasetMetaData = QVector<QgsMeshDatasetMetadata>( mDatasetTimes.count() );
+
+  //to fill metadata, calculate all the datasets one time
+  int i = 0;
+  while ( i < mDatasetTimes.count() )
+  {
+    mCurrentDatasetIndex = i;
+    if ( calculateDataset() )
+      ++i; //calculation succeeds
+    else
+      mDatasetTimes.removeAt( i ); //calculation fails, remove this time step
+  }
+
+  calculateStatistic();
+}
+
+int QgsMeshVirtualDatasetGroup::datasetCount() const
+{
+  return mDatasetTimes.count();
+}
+
+QgsMeshDataset *QgsMeshVirtualDatasetGroup::dataset( int index ) const
+{
+  if ( index < 0 || index >= mDatasetTimes.count() )
+    return nullptr;
+
+  if ( index != mCurrentDatasetIndex )
+  {
+    mCurrentDatasetIndex = index;
+    calculateDataset();
+  }
+
+  return mCacheDataset.get();
+}
+
+QgsMeshDatasetMetadata QgsMeshVirtualDatasetGroup::datasetMetadata( int datasetIndex ) const
+{
+  if ( datasetIndex < 0 && datasetIndex >= mDatasetMetaData.count() )
+    return QgsMeshDatasetMetadata();
+
+  return mDatasetMetaData.at( datasetIndex );
+}
+
+QStringList QgsMeshVirtualDatasetGroup::datasetGroupNamesDependentOn() const
+{
+  return mDatasetGroupNameUsed;
+}
+
+QDomElement QgsMeshVirtualDatasetGroup::writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const
+{
+  Q_UNUSED( context )
+  QDomElement elemDataset = doc.createElement( QStringLiteral( "mesh-dataset" ) );
+  elemDataset.setAttribute( QStringLiteral( "source-type" ), QStringLiteral( "virtual" ) );
+  elemDataset.setAttribute( QStringLiteral( "name" ), name() );
+  elemDataset.setAttribute( QStringLiteral( "formula" ), mFormula );
+  elemDataset.setAttribute( QStringLiteral( "startTime" ), mStartTime );
+  elemDataset.setAttribute( QStringLiteral( "endTime" ), mEndTime );
+
+  return elemDataset;
+}
+
+QString QgsMeshVirtualDatasetGroup::description() const
+{
+  return mFormula;
+}
+
+bool QgsMeshVirtualDatasetGroup::calculateDataset() const
+{
+  if ( !mLayer )
+    return false;
+
+  QgsMeshCalcUtils dsu( mLayer, mDatasetGroupNameUsed, QgsInterval( mDatasetTimes[mCurrentDatasetIndex] / 1000.0 ) );
+
+  if ( !dsu.isValid() )
+    return false;
+
+  //open output dataset
+  std::unique_ptr<QgsMeshMemoryDatasetGroup> outputGroup = qgis::make_unique<QgsMeshMemoryDatasetGroup> ( QString(), dsu.outputType() );
+  mCalcNode->calculate( dsu, *outputGroup );
+
+  if ( outputGroup->memoryDatasets.isEmpty() )
+    return false;
+
+  mCacheDataset = outputGroup->memoryDatasets[0];
+  if ( !mDatasetMetaData[mCurrentDatasetIndex].isValid() )
+  {
+    mCacheDataset->calculateMinMax();
+    mCacheDataset->time = mDatasetTimes[mCurrentDatasetIndex] / 3600.0 / 1000.0;
+    mDatasetMetaData[mCurrentDatasetIndex] = mCacheDataset->metadata();
+  }
+
+  return true;
+}
+
+QgsMeshDatasetGroup *QgsMeshVirtualDatasetGroupGenerator::createVirtualDatasetGroupFromFormula( const QString &name, const QString &formulaString, QgsMeshLayer *layer, qint64 relativeStartTime, qint64 relativeEndTime )
+{
+  return new QgsMeshVirtualDatasetGroup( name, formulaString, layer, relativeStartTime, relativeEndTime );
+}

--- a/src/analysis/mesh/qgsmeshvirtualdatasetgroup.h
+++ b/src/analysis/mesh/qgsmeshvirtualdatasetgroup.h
@@ -1,0 +1,85 @@
+/***************************************************************************
+                         qgsmeshvirtualdatasetgroup.h
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMESHVIRTUALDATASETGROUP_H
+#define QGSMESHVIRTUALDATASETGROUP_H
+
+#include "qgsmeshdataset.h"
+#include "qgsmeshcalcnode.h"
+#include "qgsmeshdatagenerator.h"
+
+#include "qgsmeshlayertemporalproperties.h"
+
+#define SIP_NO_FILE
+
+class ANALYSIS_EXPORT QgsMeshVirtualDatasetGroup: public QgsMeshDatasetGroup
+{
+  public:
+    /**
+     * Constructor
+     * \param name name of the dataset group
+     * \param formulaString formula use to define the dataset group
+     * \param layer mesh layer that contains dataset group
+     * \param relativeStartTime relative time start, in mimliseconds, from the mesh layer provider reference time
+     * \param relativeEndTime relative time end, in mimliseconds, from the mesh layer provider reference time
+     */
+    QgsMeshVirtualDatasetGroup( const QString &name,
+                                const QString &formulaString,
+                                QgsMeshLayer *layer,
+                                qint64 relativeStartTime,
+                                qint64 relativeEndTime );
+
+    void initialize() override;
+    int datasetCount() const override;
+    QgsMeshDataset *dataset( int index ) const override;
+    QgsMeshDatasetMetadata datasetMetadata( int datasetIndex ) const override;
+    QStringList datasetGroupNamesDependentOn() const override;
+    QDomElement writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const override;
+    QString description() const override;
+    QgsMeshDatasetGroup::Type type() const override {return QgsMeshDatasetGroup::Virtual;}
+
+  private:
+    QString mFormula;
+    std::unique_ptr<QgsMeshCalcNode> mCalcNode;
+    QgsMeshLayer *mLayer = nullptr;
+    qint64 mStartTime = 0.0;
+    qint64 mEndTime = 0.0;
+    QStringList mDatasetGroupNameUsed;
+    QList<qint64> mDatasetTimes;
+
+    mutable std::shared_ptr<QgsMeshMemoryDataset> mCacheDataset;
+    mutable QVector<QgsMeshDatasetMetadata> mDatasetMetaData;
+    mutable int mCurrentDatasetIndex = -1;
+
+    bool calculateDataset() const;
+};
+
+
+class ANALYSIS_EXPORT QgsMeshVirtualDatasetGroupGenerator: public QgsMeshDataGeneratorInterface
+{
+  public:
+
+    QgsMeshDatasetGroup *createVirtualDatasetGroupFromFormula( const QString &name,
+        const QString &formulaString,
+        QgsMeshLayer *layer,
+        qint64 relativeStartTime,
+        qint64 relativeEndTime ) override;
+
+    QString key() const override {return QStringLiteral( "virtual" );}
+};
+
+#endif // QGSMESHVIRTUALDATASETGROUP_H

--- a/src/app/mesh/qgsmeshcalculatordialog.h
+++ b/src/app/mesh/qgsmeshcalculatordialog.h
@@ -128,6 +128,7 @@ class APP_EXPORT QgsMeshCalculatorDialog: public QDialog, private Ui::QgsMeshCal
 
     QgsMeshLayer *mLayer;
     QHash<QString, QgsMeshDriverMetadata> mMeshDrivers;
+    QStringList mVariableNames;
 
     friend class TestQgsMeshCalculatorDialog;
 };

--- a/src/app/mesh/qgsmeshdatasetgrouptreeview.cpp
+++ b/src/app/mesh/qgsmeshdatasetgrouptreeview.cpp
@@ -28,6 +28,7 @@
 #include <QMenu>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QHeaderView>
 
 
 QgsMeshDatasetGroupTreeModel::QgsMeshDatasetGroupTreeModel( QObject *parent )
@@ -42,52 +43,28 @@ int QgsMeshDatasetGroupTreeModel::columnCount( const QModelIndex &parent ) const
   return 1;
 }
 
-bool QgsMeshDatasetGroupTreeModel::setData( const QModelIndex &index, const QVariant &value, int role )
-{
-  if ( !index.isValid() )
-    return false;
-
-  QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
-
-  switch ( role )
-  {
-    case Qt::EditRole:
-      if ( value != QString() )
-      {
-        item->setName( value.toString() );
-        return true;
-      }
-      break;
-    case Qt::CheckStateRole :
-      item->setIsEnabled( value.toBool() );
-      return true;
-  }
-  return false;
-}
-
 QVariant QgsMeshDatasetGroupTreeModel::data( const QModelIndex &index, int role ) const
 {
   if ( !index.isValid() )
     return QVariant();
 
   QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
+  if ( !item )
+    return QVariant();
 
   switch ( role )
   {
     case Qt::DisplayRole:
     case Name:
       return item->name();
-    case IsVector:
-      return item->isVector();
+      break;
+    case Qt::CheckStateRole :
+      if ( index.column() == 0 )
+        return static_cast< int >( item->isEnabled() ? Qt::Checked : Qt::Unchecked );
+      break;
     case DatasetGroupIndex:
       return item->datasetGroupIndex();
-    case Qt::CheckStateRole :
-      return static_cast< int >( item->isEnabled() ? Qt::Checked : Qt::Unchecked );
-    case IsMemory:
-      return item->storageType() == QgsMeshDatasetGroupTreeItem::Memory;
-    case Qt::DecorationRole:
-      if ( item->storageType() == QgsMeshDatasetGroupTreeItem::Memory )
-        return QgsApplication::getThemeIcon( QStringLiteral( "mIndicatorMemory.svg" ) );
+      break;
   }
 
   return QVariant();
@@ -187,6 +164,14 @@ QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupTreeModel::datasetGroupTreeItem(
     return nullptr;
 }
 
+QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupTreeModel::datasetGroupTreeItem( QModelIndex index )
+{
+  if ( !index.isValid() || !hasIndex( index.row(), index.column(), index.parent() ) )
+    return nullptr;
+
+  return static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
+}
+
 bool QgsMeshDatasetGroupTreeModel::isEnabled( const QModelIndex &index ) const
 {
   if ( !index.isValid() )
@@ -232,7 +217,7 @@ void QgsMeshDatasetGroupTreeModel::removeItem( const QModelIndex &index )
     return;
 
   QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
-  if ( !item || item->storageType() == QgsMeshDatasetGroupTreeItem::File )
+  if ( !item || item->datasetGroupType() == QgsMeshDatasetGroup::Persistent )
     return;
 
   beginRemoveRows( index.parent(), index.row(), index.row() );
@@ -241,7 +226,7 @@ void QgsMeshDatasetGroupTreeModel::removeItem( const QModelIndex &index )
   endRemoveRows();
 }
 
-void QgsMeshDatasetGroupTreeModel::setStorageType( const QModelIndex &index, QgsMeshDatasetGroupTreeItem::StorageType type )
+void QgsMeshDatasetGroupTreeModel::setPersistentDatasetGroup( const QModelIndex &index, const QString &uri )
 {
   if ( !index.isValid() )
     return;
@@ -249,7 +234,7 @@ void QgsMeshDatasetGroupTreeModel::setStorageType( const QModelIndex &index, Qgs
   QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
   if ( !item )
     return;
-  item->setStorageType( type );
+  item->setPersistentDatasetGroup( uri );
   dataChanged( index, index );
 }
 
@@ -313,6 +298,8 @@ QVariant QgsMeshDatasetGroupProxyModel::data( const QModelIndex &index, int role
 
   switch ( role )
   {
+    case QgsMeshDatasetGroupTreeModel::IsVector:
+      return item->isVector();
     case QgsMeshDatasetGroupTreeModel::IsActiveScalarDatasetGroup:
       return item->datasetGroupIndex() == mActiveScalarGroupIndex;
     case QgsMeshDatasetGroupTreeModel::IsActiveVectorDatasetGroup:
@@ -320,6 +307,8 @@ QVariant QgsMeshDatasetGroupProxyModel::data( const QModelIndex &index, int role
     case Qt::CheckStateRole :
       return QVariant();
     case Qt::DecorationRole:
+      return QVariant();
+    case Qt::BackgroundColorRole:
       return QVariant();
   }
 
@@ -535,6 +524,9 @@ QVariant QgsMeshDatasetGroupListModel::data( const QModelIndex &index, int role 
       else
         return item->name();
       break;
+    case Qt::DecorationRole:
+      return QVariant();
+      break;
   }
 
   return QVariant();
@@ -545,14 +537,27 @@ void QgsMeshDatasetGroupListModel::setDisplayProviderName( bool displayProviderN
   mDisplayProviderName = displayProviderName;
 }
 
+QStringList QgsMeshDatasetGroupListModel::variableNames() const
+{
+  int varCount = rowCount( QModelIndex() );
+  QStringList variableNames;
+  for ( int i = 0; i < varCount; ++i )
+    variableNames.append( data( createIndex( i, 0 ), Qt::DisplayRole ).toString() );
+
+  return variableNames;
+}
+
 QgsMeshDatasetGroupTreeView::QgsMeshDatasetGroupTreeView( QWidget *parent ):
   QTreeView( parent )
-  , mModel( new QgsMeshDatasetGroupTreeModel( this ) )
+  , mModel( new QgsMeshAvailableDatasetGroupTreeModel( this ) )
   , mSaveMenu( new QgsMeshDatasetGroupSaveMenu( this ) )
 {
-  setItemDelegate( &mDelegate );
+  // To avoid the theme style overrides the background defined by the model
+  setStyleSheet( "QgsMeshDatasetGroupTreeView::item {background:none}" );
+
   setModel( mModel );
   setSelectionMode( QAbstractItemView::SingleSelection );
+  header()->setSectionResizeMode( QHeaderView::ResizeToContents );
 
   connect( mSaveMenu, &QgsMeshDatasetGroupSaveMenu::datasetGroupSaved, this, &QgsMeshDatasetGroupTreeView::onDatasetGroupSaved );
 }
@@ -588,13 +593,36 @@ void QgsMeshDatasetGroupTreeView::contextMenuEvent( QContextMenuEvent *event )
 
 void QgsMeshDatasetGroupTreeView::removeCurrentItem()
 {
-  if ( QMessageBox::question( this, tr( "Remove Dataset Group" ), tr( "Remove dataset group?" ) ) == QMessageBox::Ok )
+  QgsMeshDatasetGroupTreeItem *item = mModel->datasetGroupTreeItem( currentIndex() );
+
+  if ( item )
+  {
+    QList<int> dependencies = item->groupIndexDependencies();
+    if ( !dependencies.isEmpty() )
+    {
+      QString varList;
+      for ( int dependentGroupIndex : dependencies )
+      {
+        QgsMeshDatasetGroupTreeItem *item = mModel->datasetGroupTreeItem( dependentGroupIndex );
+        if ( item )
+        {
+          varList.append( item->name() );
+          varList.append( QStringLiteral( "\n" ) );
+        }
+      }
+      QMessageBox::information( this, tr( "Remove Dataset Group" ), tr( "This dataset group can be removed because it has the following dependencies :\n%1" )
+                                .arg( varList ) );
+      return;
+    }
+  }
+
+  if ( QMessageBox::question( this, tr( "Remove Dataset Group" ), tr( "Remove dataset group?" ) ) == QMessageBox::Yes )
     mModel->removeItem( currentIndex() );
 }
 
-void QgsMeshDatasetGroupTreeView::onDatasetGroupSaved()
+void QgsMeshDatasetGroupTreeView::onDatasetGroupSaved( const QString &uri )
 {
-  mModel->setStorageType( currentIndex(), QgsMeshDatasetGroupTreeItem::File );
+  mModel->setPersistentDatasetGroup( currentIndex(), uri );
   emit apply();
 }
 
@@ -612,14 +640,14 @@ QMenu *QgsMeshDatasetGroupTreeView::createContextMenu()
   if ( !item )
     return nullptr;
 
-  switch ( item->storageType() )
+  switch ( item->datasetGroupType() )
   {
-    case QgsMeshDatasetGroupTreeItem::None:
+    case QgsMeshDatasetGroup::None:
       break;
-    case QgsMeshDatasetGroupTreeItem::File:
+    case QgsMeshDatasetGroup::Persistent:
       break;
-    case QgsMeshDatasetGroupTreeItem::Memory:
-    case QgsMeshDatasetGroupTreeItem::OnTheFly:
+    case QgsMeshDatasetGroup::Memory:
+    case QgsMeshDatasetGroup::Virtual:
       contextMenu->addAction( tr( "Remove Dataset Group" ), this, &QgsMeshDatasetGroupTreeView::removeCurrentItem );
       mSaveMenu->createSaveMenu( groupIndex, contextMenu );
       break;
@@ -719,19 +747,117 @@ void QgsMeshDatasetGroupSaveMenu::saveDatasetGroup( int datasetGroup, const QStr
   }
   else
   {
-    emit datasetGroupSaved();
+    emit datasetGroupSaved( saveFileName );
     QMessageBox::information( nullptr, QObject::tr( "Save Mesh Datasets" ), QObject::tr( "Datasets successfully saved on file" ) );
   }
 
 }
 
-QgsMeshDatasetGroupTreeView::Delegate::Delegate( QObject *parent ): QStyledItemDelegate( parent )
+QgsMeshAvailableDatasetGroupTreeModel::QgsMeshAvailableDatasetGroupTreeModel( QObject *parent ): QgsMeshDatasetGroupTreeModel( parent )
+{}
+
+QVariant QgsMeshAvailableDatasetGroupTreeModel::data( const QModelIndex &index, int role ) const
 {
+  if ( !index.isValid() )
+    return QVariant();
+
+  switch ( role )
+  {
+    case Qt::DisplayRole:
+    case Name:
+      return textDisplayed( index );
+    case Qt::BackgroundColorRole:
+      return backGroundColor( index );
+  }
+  return QgsMeshDatasetGroupTreeModel::data( index, role );
 }
 
-void QgsMeshDatasetGroupTreeView::Delegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
+bool QgsMeshAvailableDatasetGroupTreeModel::setData( const QModelIndex &index, const QVariant &value, int role )
 {
-  QStyleOptionViewItem opt = option;
-  opt.decorationPosition = QStyleOptionViewItem::Right;
-  QStyledItemDelegate::paint( painter, opt, index );
+  if ( !index.isValid() )
+    return false;
+
+  QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
+  if ( !item )
+    return false;
+
+  switch ( role )
+  {
+    case Qt::EditRole:
+      if ( value != QString() )
+      {
+        item->setName( value.toString() );
+        return true;
+      }
+      break;
+    case Qt::CheckStateRole :
+      item->setIsEnabled( value.toBool() );
+      return true;
+  }
+  return false;
+}
+
+Qt::ItemFlags QgsMeshAvailableDatasetGroupTreeModel::flags( const QModelIndex &index ) const
+{
+  if ( !index.isValid() )
+    return Qt::NoItemFlags;
+
+  if ( index.column() > 0 )
+    return Qt::ItemIsEnabled;
+
+  return Qt::ItemIsEnabled | Qt::ItemIsUserCheckable | Qt::ItemIsEditable;
+}
+
+QVariant QgsMeshAvailableDatasetGroupTreeModel::headerData( int section, Qt::Orientation orientation, int role ) const
+{
+  Q_UNUSED( section )
+
+  if ( orientation == Qt::Horizontal && role == Qt::DisplayRole )
+  {
+    if ( section == 0 )
+      return tr( "Groups" );
+    if ( section == 1 )
+      return  tr( "Type" );
+    if ( section == 2 )
+      return  tr( "Description" );
+  }
+
+  return QVariant();
+}
+
+int QgsMeshAvailableDatasetGroupTreeModel::columnCount( const QModelIndex &parent ) const {Q_UNUSED( parent ); return 3;}
+
+QString QgsMeshAvailableDatasetGroupTreeModel::textDisplayed( const QModelIndex &index ) const
+{
+  QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
+  if ( !item )
+    return QString();
+
+  switch ( index.column() )
+  {
+    case 0:
+      return item->name();
+    case 1:
+      if ( item->isVector() )
+        return tr( "Vector" );
+      else
+        return tr( "Scalar" );
+    case 2 :
+      return item->description();
+  }
+  return QString();
+}
+
+QColor QgsMeshAvailableDatasetGroupTreeModel::backGroundColor( const QModelIndex &index ) const
+{
+  QgsMeshDatasetGroupTreeItem *item = static_cast<QgsMeshDatasetGroupTreeItem *>( index.internalPointer() );
+  if ( !item )
+    return QColor();
+
+  if ( item->datasetGroupType() == QgsMeshDatasetGroup::Virtual )
+    return QColor( 103, 0, 243, 44 );
+  else if ( item->datasetGroupType() == QgsMeshDatasetGroup::Memory )
+    return QColor( 252, 155, 79, 44 );
+  else
+    return QColor( 252, 255, 79, 44 );
 }

--- a/src/app/mesh/qgsmeshdatasetgrouptreewidget.cpp
+++ b/src/app/mesh/qgsmeshdatasetgrouptreewidget.cpp
@@ -43,7 +43,6 @@ QgsMeshDatasetGroupTreeWidget::QgsMeshDatasetGroupTreeWidget( QWidget *parent ):
   } );
 
   connect( mDatasetGroupTreeView, &QgsMeshDatasetGroupTreeView::apply, this, &QgsMeshDatasetGroupTreeWidget::apply );
-
 }
 
 void QgsMeshDatasetGroupTreeWidget::syncToLayer( QgsMeshLayer *meshLayer )

--- a/src/app/mesh/qgsmeshstaticdatasetwidget.h
+++ b/src/app/mesh/qgsmeshstaticdatasetwidget.h
@@ -26,7 +26,7 @@ class QgsMeshDataProvider;
 
 
 /**
- * List mdel for dataset contained in dataset group,
+ * List model for dataset contained in dataset group,
  * used to display by time dataset in widget
  */
 class APP_NO_EXPORT QgsMeshDatasetListModel: public QAbstractListModel

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -308,6 +308,7 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 #include "qgsquerybuilder.h"
 #include "qgsrastercalcdialog.h"
 #include "qgsmeshcalculatordialog.h"
+#include "qgsmeshvirtualdatasetgroup.h"
 #include "qgsrasterfilewriter.h"
 #include "qgsrasterfilewritertask.h"
 #include "qgsrasteriterator.h"
@@ -1085,6 +1086,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   functionProfile( &QgisApp::updateProjectFromTemplates, this, QStringLiteral( "Update project from templates" ) );
   functionProfile( &QgisApp::legendLayerSelectionChanged, this, QStringLiteral( "Legend layer selection changed" ) );
   functionProfile( &QgisApp::init3D, this, QStringLiteral( "Initialize 3D support" ) );
+  functionProfile( &QgisApp::initMeshDataGenerator, this, QStringLiteral( "Initialize mesh calculator" ) );
   functionProfile( &QgisApp::initNativeProcessing, this, QStringLiteral( "Initialize native processing" ) );
   functionProfile( &QgisApp::initLayouts, this, QStringLiteral( "Initialize layouts support" ) );
 
@@ -12617,6 +12619,11 @@ void QgisApp::init3D()
 #endif
 }
 
+void QgisApp::initMeshDataGenerator()
+{
+  QgsApplication::instance()->meshDataGeneratorRegistry()->addMeshDataGenerator( new QgsMeshVirtualDatasetGroupGenerator );
+}
+
 void QgisApp::initNativeProcessing()
 {
   QgsApplication::processingRegistry()->addProvider( new QgsNativeAlgorithms( QgsApplication::processingRegistry() ) );
@@ -12893,7 +12900,6 @@ bool QgisApp::checkMemoryLayers()
   // check to see if there are any temporary layers present (with features)
   bool hasTemporaryLayers = false;
   bool hasMemoryLayers = false;
-  bool hasMemoryMeshLayerDatasetGroup = false;
 
   const QMap<QString, QgsMapLayer *> layers = QgsProject::instance()->mapLayers();
   for ( auto it = layers.begin(); it != layers.end(); ++it )
@@ -12909,10 +12915,7 @@ bool QgisApp::checkMemoryLayers()
     }
     else if ( it.value() && it.value()->isTemporary() )
     {
-      if ( it.value()->type() == QgsMapLayerType::MeshLayer )
-        hasMemoryMeshLayerDatasetGroup = true;
-      else
-        hasTemporaryLayers = true;
+      hasTemporaryLayers = true;
     }
   }
 
@@ -12927,12 +12930,6 @@ bool QgisApp::checkMemoryLayers()
     close &= QMessageBox::warning( this,
                                    tr( "Close Project" ),
                                    tr( "This project includes one or more temporary scratch layers. These layers are not saved to disk and their contents will be permanently lost. Are you sure you want to proceed?" ),
-                                   QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Yes;
-
-  if ( hasMemoryMeshLayerDatasetGroup )
-    close &= QMessageBox::warning( this,
-                                   tr( "Close Project" ),
-                                   tr( "This project includes one or more memory mesh layer dataset groups. These dataset groups are not saved to disk and their contents will be permanently lost. Are you sure you want to proceed?" ),
                                    QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel ) == QMessageBox::Yes;
 
   return close;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -2103,6 +2103,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void createMapTips();
     void createDecorations();
     void init3D();
+    void initMeshDataGenerator();
     void initNativeProcessing();
     void initLayouts();
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -604,6 +604,7 @@ SET(QGIS_CORE_SRCS
   mesh/qgsmeshtracerenderer.cpp
   mesh/qgsmeshvectorrenderer.cpp
   mesh/qgstriangularmesh.cpp
+  mesh/qgsmeshdatagenerator.cpp
 
   labeling/qgslabelfeature.cpp
   labeling/qgslabelingengine.cpp
@@ -1245,6 +1246,7 @@ SET(QGIS_CORE_HDRS
   mesh/qgsmeshtracerenderer.h
   mesh/qgsmeshvectorrenderer.h
   mesh/qgstriangularmesh.h
+  mesh/qgsmeshdatagenerator.h
 
   metadata/qgsabstractmetadatabase.h
   metadata/qgslayermetadata.h

--- a/src/core/mesh/qgsmeshdatagenerator.cpp
+++ b/src/core/mesh/qgsmeshdatagenerator.cpp
@@ -1,0 +1,42 @@
+/***************************************************************************
+                         qgsmeshdatagenerator.cpp
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmeshdatagenerator.h"
+#include "qgsmeshdataset.h"
+
+QgsMeshDataGeneratorInterface::QgsMeshDataGeneratorInterface() = default;
+
+QgsMeshDataGeneratorInterface::~QgsMeshDataGeneratorInterface() = default;
+
+
+QgsMeshDataGeneratorRegistry::~QgsMeshDataGeneratorRegistry()
+{
+  qDeleteAll( mMeshDataGenerators );
+}
+
+void QgsMeshDataGeneratorRegistry::addMeshDataGenerator( QgsMeshDataGeneratorInterface *generator )
+{
+  mMeshDataGenerators[generator->key()] = generator;
+}
+
+QgsMeshDataGeneratorInterface *QgsMeshDataGeneratorRegistry::meshDataGenerator( const QString &key ) const
+{
+  if ( mMeshDataGenerators.contains( key ) )
+    return mMeshDataGenerators[key];
+  else
+    return nullptr;
+}

--- a/src/core/mesh/qgsmeshdatagenerator.h
+++ b/src/core/mesh/qgsmeshdatagenerator.h
@@ -1,0 +1,84 @@
+/***************************************************************************
+                         qgsmeshdatagenerator.h
+                         ---------------------
+    begin                : June 2020
+    copyright            : (C) 2020 by Vincent Cloarec
+    email                : vcloarec at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMESHGENERATOR_H
+#define QGSMESHGENERATOR_H
+
+#include <QString>
+#include <QMap>
+
+#include "qgis_core.h"
+
+#define SIP_NO_FILE
+
+class QgsMeshDatasetGroup;
+class QgsMeshLayer;
+
+/**
+ * \ingroup core
+ *
+ * Abstract class that is an interface for mesh data generator.
+ *
+ * Mesh generator can be used to create mesh data as virtual dataset group.
+ *
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsMeshDataGeneratorInterface
+{
+  public:
+    QgsMeshDataGeneratorInterface();
+    virtual ~QgsMeshDataGeneratorInterface();
+
+    //! Creates a new virtual dataset group from a formula. The caller takes the ownership of this instance
+    virtual QgsMeshDatasetGroup *createVirtualDatasetGroupFromFormula( const QString &name,
+        const QString &formulaString,
+        QgsMeshLayer *layer,
+        qint64 relativeStartTime,
+        qint64 relativeEndTime ) = 0;
+
+    //! Returns the key of the mesh calculator
+    virtual QString key() const = 0;
+};
+
+/**
+ * \ingroup core
+ *
+ * Registry for various mesh data generators.
+ *
+ * QgsMeshDataGeneratorRegistry is not usually directly created, but rather accessed through
+ * QgsApplication::meshDataGeneratorRegistry().
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsMeshDataGeneratorRegistry
+{
+  public:
+    //! Constructor
+    QgsMeshDataGeneratorRegistry() = default;
+
+    //!Destructor
+    ~QgsMeshDataGeneratorRegistry();
+
+    //! Add a mesh calculator factory in the registry
+    void addMeshDataGenerator( QgsMeshDataGeneratorInterface *generator );
+
+    //! Returns the mesh calculator corresonding to the \a key
+    QgsMeshDataGeneratorInterface *meshDataGenerator( const QString &key ) const;
+  private:
+    QMap<QString, QgsMeshDataGeneratorInterface *> mMeshDataGenerators;
+
+};
+#endif // QGSMESHGENERATOR_H

--- a/src/core/mesh/qgsmeshdataset.cpp
+++ b/src/core/mesh/qgsmeshdataset.cpp
@@ -443,11 +443,11 @@ void QgsMesh3dDataBlock::setValid( bool valid )
 
 QgsMeshDatasetGroupTreeItem::QgsMeshDatasetGroupTreeItem() = default;
 
-QgsMeshDatasetGroupTreeItem::QgsMeshDatasetGroupTreeItem( const QString &defaultName, const QString &providerName,
+QgsMeshDatasetGroupTreeItem::QgsMeshDatasetGroupTreeItem( const QString &defaultName, const QString &sourceName,
     bool isVector,
     int index )
   : mOriginalName( defaultName )
-  , mProviderName( providerName )
+  , mSourceName( sourceName )
   , mIsVector( isVector )
   , mDatasetGroupIndex( index )
 {
@@ -462,8 +462,8 @@ QgsMeshDatasetGroupTreeItem::QgsMeshDatasetGroupTreeItem( const QDomElement &ite
   if ( itemElement.hasAttribute( QStringLiteral( "original-name" ) ) )
     mOriginalName = itemElement.attribute( QStringLiteral( "original-name" ), mOriginalName );
 
-  if ( itemElement.hasAttribute( QStringLiteral( "provider-name" ) ) )
-    mProviderName = itemElement.attribute( QStringLiteral( "provider-name" ), mProviderName );
+  if ( itemElement.hasAttribute( QStringLiteral( "source-name" ) ) )
+    mSourceName = itemElement.attribute( QStringLiteral( "source-name" ), mSourceName );
 
   if ( itemElement.hasAttribute( QStringLiteral( "is-vector" ) ) )
     mIsVector = itemElement.attribute( QStringLiteral( "is-vector" ) ).toInt();
@@ -474,27 +474,57 @@ QgsMeshDatasetGroupTreeItem::QgsMeshDatasetGroupTreeItem( const QDomElement &ite
   if ( itemElement.hasAttribute( QStringLiteral( "is-enabled" ) ) )
     mIsEnabled = itemElement.attribute( QStringLiteral( "is-enabled" ) ).toInt();
 
+  if ( itemElement.hasAttribute( QStringLiteral( "dataset-group-type" ) ) )
+    mDatasetGroupType = static_cast<QgsMeshDatasetGroup::Type>( itemElement.attribute( QStringLiteral( "dataset-group-type" ) ) .toInt() ) ;
+
+  if ( itemElement.hasAttribute( QStringLiteral( "description" ) ) )
+    mDescription = itemElement.attribute( QStringLiteral( "description" ) );
+
+  QDomElement dependOnElement = itemElement.firstChildElement( QStringLiteral( "dependent-on-item" ) );
+  while ( !dependOnElement.isNull() )
+  {
+    if ( dependOnElement.hasAttribute( QStringLiteral( "dataset-index" ) ) )
+      mDatasetGroupDependentOn.append( dependOnElement.attribute( QStringLiteral( "dataset-index" ) ).toInt() );
+    dependOnElement = dependOnElement.nextSiblingElement( QStringLiteral( "dependent-on-item" ) );
+  }
+
+  QDomElement dependencieElement = itemElement.firstChildElement( QStringLiteral( "dependencies-item" ) );
+  while ( !dependencieElement.isNull() )
+  {
+    if ( dependencieElement.hasAttribute( QStringLiteral( "dataset-index" ) ) )
+      mDatasetGroupDependencies.append( dependencieElement.attribute( QStringLiteral( "dataset-index" ) ).toInt() );
+    dependencieElement = dependencieElement.nextSiblingElement( QStringLiteral( "dependencies-item" ) );
+  }
+
   QDomElement childElement = itemElement.firstChildElement( QStringLiteral( "mesh-dataset-group-tree-item" ) );
   while ( !childElement.isNull() )
   {
     appendChild( new QgsMeshDatasetGroupTreeItem( childElement, context ) );
     childElement = childElement.nextSiblingElement( QStringLiteral( "mesh-dataset-group-tree-item" ) );
   }
-
 }
 
 QgsMeshDatasetGroupTreeItem::~QgsMeshDatasetGroupTreeItem()
 {
+  // Remove from where this item is linked
+
+  freeAsDependency();
+  freeFromDependencies();
   qDeleteAll( mChildren );
+  if ( mParent )
+  {
+    mParent->mDatasetGroupIndexToChild.remove( mDatasetGroupIndex );
+    mParent->mChildren.removeOne( this );
+  }
 }
 
 QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupTreeItem::clone() const
 {
-  QgsMeshDatasetGroupTreeItem *other = new QgsMeshDatasetGroupTreeItem( mOriginalName, mProviderName, mIsVector, mDatasetGroupIndex );
-  other->mUserName = mUserName;
-  other->mIsEnabled = mIsEnabled;
-  other->mStoreType = mStoreType;
+  QgsMeshDatasetGroupTreeItem *other = new QgsMeshDatasetGroupTreeItem( mOriginalName, mSourceName, mIsVector, mDatasetGroupIndex );
+  *other = *this;
 
+  other->mChildren.clear();
+  other->mDatasetGroupIndexToChild.clear();
   if ( !mChildren.empty() )
     for ( int i = 0; i < mChildren.count(); ++i )
       other->appendChild( mChildren.at( i )->clone() );
@@ -511,8 +541,6 @@ void QgsMeshDatasetGroupTreeItem::appendChild( QgsMeshDatasetGroupTreeItem *item
 
 void QgsMeshDatasetGroupTreeItem::removeChild( QgsMeshDatasetGroupTreeItem *item )
 {
-  mChildren.removeOne( item );
-  mDatasetGroupIndexToChild.remove( item->datasetGroupIndex() );
   delete item;
 }
 
@@ -608,9 +636,38 @@ QString QgsMeshDatasetGroupTreeItem::defaultName() const
   return mOriginalName;
 }
 
-QgsMeshDatasetGroupTreeItem::StorageType QgsMeshDatasetGroupTreeItem::storageType() const {return mStoreType;}
+QgsMeshDatasetGroup::Type QgsMeshDatasetGroupTreeItem::datasetGroupType() const
+{
+  return mDatasetGroupType;
+}
 
-void QgsMeshDatasetGroupTreeItem::setStorageType( QgsMeshDatasetGroupTreeItem::StorageType storeType ) {mStoreType = storeType;}
+QString QgsMeshDatasetGroupTreeItem::description() const
+{
+  return mDescription;
+}
+
+void QgsMeshDatasetGroupTreeItem::setDatasetGroup( QgsMeshDatasetGroup *datasetGroup )
+{
+  if ( datasetGroup )
+  {
+    mDescription = datasetGroup->description();
+    mDatasetGroupType = datasetGroup->type();
+    const QStringList &datasetGroupNames = datasetGroup->datasetGroupNamesDependentOn();
+    for ( const QString &varName : datasetGroupNames )
+    {
+      QgsMeshDatasetGroupTreeItem *varItem = searchItemBySourceName( varName );
+      varItem->mDatasetGroupDependencies.append( this->datasetGroupIndex() );
+      mDatasetGroupDependentOn.append( varItem->datasetGroupIndex() );
+    }
+  }
+}
+
+void QgsMeshDatasetGroupTreeItem::setPersistentDatasetGroup( const QString &uri )
+{
+  mDatasetGroupType = QgsMeshDatasetGroup::Persistent;
+  mDatasetGroupDependentOn.clear();
+  mDescription = uri;
+}
 
 QDomElement QgsMeshDatasetGroupTreeItem::writeXml( QDomDocument &doc, const QgsReadWriteContext &context )
 {
@@ -618,11 +675,27 @@ QDomElement QgsMeshDatasetGroupTreeItem::writeXml( QDomDocument &doc, const QgsR
 
   QDomElement itemElement = doc.createElement( QStringLiteral( "mesh-dataset-group-tree-item" ) );
   itemElement.setAttribute( QStringLiteral( "display-name" ), mUserName );
-  itemElement.setAttribute( QStringLiteral( "provider-name" ), mProviderName );
+  itemElement.setAttribute( QStringLiteral( "source-name" ), mSourceName );
   itemElement.setAttribute( QStringLiteral( "original-name" ), mOriginalName );
   itemElement.setAttribute( QStringLiteral( "is-vector" ), mIsVector ? true : false );
   itemElement.setAttribute( QStringLiteral( "dataset-index" ), mDatasetGroupIndex );
   itemElement.setAttribute( QStringLiteral( "is-enabled" ), mIsEnabled ? true : false );
+  itemElement.setAttribute( QStringLiteral( "dataset-group-type" ), mDatasetGroupType );
+  itemElement.setAttribute( QStringLiteral( "description" ), mDescription );
+
+  for ( int index : mDatasetGroupDependentOn )
+  {
+    QDomElement dependOnElement = doc.createElement( QStringLiteral( "dependent-on-item" ) );
+    dependOnElement.setAttribute( QStringLiteral( "dataset-index" ), index );
+    itemElement.appendChild( dependOnElement );
+  }
+
+  for ( int index : mDatasetGroupDependencies )
+  {
+    QDomElement dependencieElement = doc.createElement( QStringLiteral( "dependencie-item" ) );
+    dependencieElement.setAttribute( QStringLiteral( "dataset-index" ), index );
+    itemElement.appendChild( dependencieElement );
+  }
 
   for ( int i = 0; i < mChildren.count(); ++i )
     itemElement.appendChild( mChildren.at( i )->writeXml( doc, context ) );
@@ -630,9 +703,82 @@ QDomElement QgsMeshDatasetGroupTreeItem::writeXml( QDomDocument &doc, const QgsR
   return itemElement;
 }
 
+QList<int> QgsMeshDatasetGroupTreeItem::groupIndexDependencies() const
+{
+  QList<int> dependencies;
+  QgsMeshDatasetGroupTreeItem *root = rootItem();
+  for ( int index : mDatasetGroupDependencies )
+  {
+    if ( !dependencies.contains( index ) )
+      dependencies.append( index );
+    QgsMeshDatasetGroupTreeItem *item = root->childFromDatasetGroupIndex( index );
+    if ( item )
+      dependencies.append( item->groupIndexDependencies() );
+  }
+
+  for ( int i = 0; i < childCount(); ++i )
+  {
+    dependencies.append( child( i )->groupIndexDependencies() );
+  }
+
+  return dependencies;
+}
+
+QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupTreeItem::searchItemBySourceName( const QString &sourceName ) const
+{
+
+  QgsMeshDatasetGroupTreeItem *baseItem = rootItem();
+
+  QList<QgsMeshDatasetGroupTreeItem *> itemToCheck;
+  itemToCheck.append( baseItem );
+  while ( baseItem->providerName() != sourceName && !itemToCheck.isEmpty() )
+  {
+    for ( int i = 0; i < baseItem->childCount(); ++i )
+      itemToCheck.append( baseItem->child( i ) );
+    itemToCheck.removeOne( baseItem );
+    if ( !itemToCheck.empty() )
+      baseItem = itemToCheck.first();
+    else
+      baseItem = nullptr;
+  }
+
+  return baseItem;
+}
+
+QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupTreeItem::rootItem() const
+{
+  const QgsMeshDatasetGroupTreeItem *baseItem = this;
+  while ( baseItem->parentItem() != nullptr )
+    baseItem = baseItem->parentItem();
+
+  return const_cast<QgsMeshDatasetGroupTreeItem *>( baseItem );
+}
+
+void QgsMeshDatasetGroupTreeItem::freeAsDependency()
+{
+  QgsMeshDatasetGroupTreeItem *root = rootItem();
+  for ( int index : mDatasetGroupDependentOn )
+  {
+    QgsMeshDatasetGroupTreeItem *item = root->childFromDatasetGroupIndex( index );
+    if ( item )
+      item->mDatasetGroupDependencies.removeOne( this->datasetGroupIndex() );
+  }
+}
+
+void QgsMeshDatasetGroupTreeItem::freeFromDependencies()
+{
+  QgsMeshDatasetGroupTreeItem *root = rootItem();
+  for ( int index : mDatasetGroupDependencies )
+  {
+    QgsMeshDatasetGroupTreeItem *item = root->childFromDatasetGroupIndex( index );
+    if ( item )
+      item->mDatasetGroupDependentOn.removeOne( this->datasetGroupIndex() );
+  }
+}
+
 QString QgsMeshDatasetGroupTreeItem::providerName() const
 {
-  return mProviderName;
+  return mSourceName;
 }
 
 void QgsMeshDatasetGroupTreeItem::setName( const QString &name )
@@ -685,7 +831,7 @@ QgsMeshDataBlock QgsMeshMemoryDataset::areFacesActive( int faceIndex, int count 
   return ret;
 }
 
-QgsMeshDatasetMetadata QgsMeshMemoryDataset::metaData() const
+QgsMeshDatasetMetadata QgsMeshMemoryDataset::metadata() const
 {
   return QgsMeshDatasetMetadata( time, valid, minimum, maximum, 0 );
 }
@@ -758,7 +904,7 @@ QgsMeshDatasetGroupMetadata QgsMeshDatasetGroup::groupMetadata() const
            minimum(),
            maximum(),
            0,
-           QDateTime(),
+           mReferenceTime,
            datasetCount() > 1,
            extraMetadata()
          );
@@ -769,21 +915,22 @@ int QgsMeshMemoryDatasetGroup::datasetCount() const
   return memoryDatasets.size();
 }
 
-QgsMeshDatasetMetadata QgsMeshMemoryDatasetGroup::datasetMetadata( int datasetIndex )
+QgsMeshDatasetMetadata QgsMeshMemoryDatasetGroup::datasetMetadata( int datasetIndex ) const
 {
   if ( datasetIndex >= 0 && datasetIndex < memoryDatasets.count() )
-    return memoryDatasets[datasetIndex]->metaData();
+    return memoryDatasets[datasetIndex]->metadata();
   else
     return QgsMeshDatasetMetadata();
 }
 
-const QgsMeshDataset *QgsMeshMemoryDatasetGroup::dataset( int index ) const
+QgsMeshDataset *QgsMeshMemoryDatasetGroup::dataset( int index ) const
 {
-  return memoryDatasets.at( index ).get();
+  return memoryDatasets[index].get();
 }
 
 void QgsMeshMemoryDatasetGroup::addDataset( std::shared_ptr<QgsMeshMemoryDataset> dataset )
 {
+  dataset->calculateMinMax();
   memoryDatasets.push_back( dataset );
 }
 
@@ -792,25 +939,51 @@ void QgsMeshMemoryDatasetGroup::clearDatasets()
   memoryDatasets.clear();
 }
 
+void QgsMeshMemoryDatasetGroup::initialize()
+{
+  calculateStatistic();
+}
+
 std::shared_ptr<const QgsMeshMemoryDataset> QgsMeshMemoryDatasetGroup::constDataset( int index ) const
 {
   return memoryDatasets[index];
 }
 
-void QgsMeshMemoryDatasetGroup::calculateStatistic()
+QDomElement QgsMeshMemoryDatasetGroup::writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const
+{
+  Q_UNUSED( doc )
+  Q_UNUSED( context )
+  return QDomElement();
+}
+
+void QgsMeshDatasetGroup::calculateStatistic()
 {
   double min = std::numeric_limits<double>::max();
   double max = std::numeric_limits<double>::min();
 
-  int count = memoryDatasets.size();
+  int count = datasetCount();
   for ( int i = 0; i < count; ++i )
   {
-    memoryDatasets[i]->calculateMinMax();
-    min = std::min( min, memoryDatasets[i]->minimum );
-    max = std::max( max, memoryDatasets[i]->maximum );
+    min = std::min( min,  datasetMetadata( i ).minimum() );
+    max = std::max( max, datasetMetadata( i ).maximum() );
   }
   mMinimum = min;
   mMaximum = max;
+}
+
+QStringList QgsMeshDatasetGroup::datasetGroupNamesDependentOn() const
+{
+  return QStringList();
+}
+
+QString QgsMeshDatasetGroup::description() const
+{
+  return QString();
+}
+
+void QgsMeshDatasetGroup::setReferenceTime( const QDateTime &referenceTime )
+{
+  mReferenceTime = referenceTime;
 }
 
 bool QgsMeshDatasetGroup::checkValueCountPerDataset( int count ) const
@@ -822,6 +995,8 @@ bool QgsMeshDatasetGroup::checkValueCountPerDataset( int count ) const
 }
 
 QgsMeshDatasetGroup::QgsMeshDatasetGroup( const QString &name, QgsMeshDatasetGroupMetadata::DataType dataType ): mName( name ), mDataType( dataType ) {}
+
+QgsMeshDatasetGroup::~QgsMeshDatasetGroup() = default;
 
 QgsMeshDatasetGroup::QgsMeshDatasetGroup( const QString &name ): mName( name ) {}
 

--- a/src/core/mesh/qgsmeshdataset.h
+++ b/src/core/mesh/qgsmeshdataset.h
@@ -29,7 +29,8 @@
 #include "qgspoint.h"
 #include "qgsdataprovider.h"
 
-
+class QgsMeshLayer;
+class QgsMeshDatasetGroup;
 class QgsRectangle;
 
 /**
@@ -412,12 +413,10 @@ class CORE_EXPORT QgsMeshDatasetGroupMetadata
      */
     bool isScalar() const;
 
-
     /**
      * \brief Returns whether the dataset group is temporal (contains time-related dataset)
      */
     bool isTemporal() const;
-
 
     /**
      * Returns whether dataset group data is defined on vertices or faces or volumes
@@ -530,6 +529,232 @@ class CORE_EXPORT QgsMeshDatasetMetadata
     int mMaximumVerticalLevelsCount = 0; // for 3d stacked meshes
 };
 
+
+/**
+ * \ingroup core
+ *
+ * Abstract class that represents a dataset
+ *
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsMeshDataset
+{
+  public:
+    //! Constructor
+    QgsMeshDataset() = default;
+
+    //! Destructor
+    virtual ~QgsMeshDataset() = default;
+
+    //! Returns the value with index \a valueIndex
+    virtual QgsMeshDatasetValue datasetValue( int valueIndex ) const = 0;
+
+    //! Returns \a count values from \a valueIndex
+    virtual QgsMeshDataBlock datasetValues( bool isScalar, int valueIndex, int count ) const = 0;
+
+    //! Returns whether faces are active
+    virtual QgsMeshDataBlock areFacesActive( int faceIndex, int count ) const = 0;
+
+    //! Returns whether the face is active
+    virtual bool isActive( int faceIndex ) const = 0;
+
+    //! Returns the metadata of the dataset
+    virtual QgsMeshDatasetMetadata metadata() const = 0;
+
+    //! Returns the values count
+    virtual int valuesCount() const = 0;
+};
+
+/**
+ * \ingroup core
+ *
+ * Abstract class that represents a dataset group
+ *
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsMeshDatasetGroup
+{
+  public:
+
+    /**
+     * Type of the dataset group
+     *
+     * \since QGIS 3.16
+     */
+    enum Type
+    {
+      None, //! Generic type used for non typed dataset group
+      Persistent, //! Dataset group store on file
+      Memory, //! Temporary dataset group in memory
+      Virtual, //! Virtual Dataset group defined by a formula
+    };
+
+    //! Default constructor
+    QgsMeshDatasetGroup() = default;
+    virtual ~QgsMeshDatasetGroup();
+
+    //! Constructor with the \a name of the dataset group
+    QgsMeshDatasetGroup( const QString &name );
+
+    //! Constructor with the \a name of the dataset group and the \a dataTYpe
+    QgsMeshDatasetGroup( const QString &name, QgsMeshDatasetGroupMetadata::DataType dataType );
+
+    //! Initialize the dataset group
+    virtual void initialize() = 0;
+
+    //! Returns the metadata of the dataset group
+    QgsMeshDatasetGroupMetadata groupMetadata() const;
+
+    //! Returns the metadata of the dataset with index \a datasetIndex
+    virtual QgsMeshDatasetMetadata datasetMetadata( int datasetIndex ) const = 0 ;
+
+    //! Returns the count of datasets in the group
+    virtual int datasetCount() const = 0;
+
+    //! Returns the dataset with \a index
+    virtual QgsMeshDataset *dataset( int index ) const = 0;
+
+    //! Returns the type of dataset group
+    virtual QgsMeshDatasetGroup::Type type() const = 0;
+
+    //! Returns the minimum value of the whole dataset group
+    double minimum() const;
+
+    //! Returns the maximum value of the whole dataset group
+    double maximum() const;
+
+    //! Overrides the minimum and the maximum value of the whole dataset group
+    void setMinimumMaximum( double min, double max );
+
+    //! Returns the name of the dataset group
+    QString name() const;
+
+    //! Sets the name of the dataset group
+    void setName( const QString &name );
+
+    //! Returns the data type of the dataset group
+    QgsMeshDatasetGroupMetadata::DataType dataType() const;
+
+    //! Sets the data type of the dataset group
+    void setDataType( const QgsMeshDatasetGroupMetadata::DataType &dataType );
+
+    //! Adds extra metadata to the group
+    void addExtraMetadata( QString key, QString value );
+    //! Returns all the extra metadata of the group
+    QMap<QString, QString> extraMetadata() const;
+
+    //! Returns whether the group contain scalar values
+    bool isScalar() const;
+
+    //! Sets whether the group contain scalar values
+    void setIsScalar( bool isScalar );
+
+    //! Returns whether all the datasets contain \a count values
+    bool checkValueCountPerDataset( int count ) const;
+
+    //! Calculates the statictics (minimum and maximum)
+    void calculateStatistic();
+
+    //! Returns the dataset group variable name which this dataset group depends on
+    virtual QStringList datasetGroupNamesDependentOn() const;
+
+    //! Write dataset group information in a DOM element
+    virtual QDomElement writeXml( QDomDocument &doc, const QgsReadWriteContext &context ) const = 0;
+
+    //! Returns some information about the dataset group
+    virtual QString description() const;
+
+    void setReferenceTime( const QDateTime &referenceTime );
+
+  protected:
+    QString mName;
+
+    QgsMeshDatasetGroupMetadata::DataType mDataType = QgsMeshDatasetGroupMetadata::DataOnVertices;
+    QMap<QString, QString> mMetadata;
+    bool mIsScalar = true;
+
+  private:
+    double mMinimum = std::numeric_limits<double>::quiet_NaN();
+    double mMaximum = std::numeric_limits<double>::quiet_NaN();
+
+    QDateTime mReferenceTime;
+};
+
+#ifndef SIP_RUN
+
+/**
+ * \ingroup core
+ *
+ * Class to store memory dataset
+ * The QgsMeshDatasetValue objects and whether the faces are active are stored in QVector containers that are exposed for efficiency
+ *
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsMeshMemoryDataset: public QgsMeshDataset
+{
+  public:
+    //! Constructor
+    QgsMeshMemoryDataset() = default;
+
+    QgsMeshDatasetValue datasetValue( int valueIndex ) const override;
+    QgsMeshDataBlock datasetValues( bool isScalar, int valueIndex, int count ) const override;
+    QgsMeshDataBlock areFacesActive( int faceIndex, int count ) const override;
+    QgsMeshDatasetMetadata metadata() const override;
+    bool isActive( int faceIndex ) const override;
+    int valuesCount() const override;
+
+    void calculateMinMax();
+
+    QVector<QgsMeshDatasetValue> values;
+    QVector<int> active;
+    double time = -1;
+    bool valid = false;
+    double minimum = std::numeric_limits<double>::quiet_NaN();
+    double maximum = std::numeric_limits<double>::quiet_NaN();
+};
+
+/**
+ * \ingroup core
+ *
+ * Class that represents a dataset group stored in memory
+ * The QgsMeshMemoryDataset objects stores in a QVector container that are exposed for efficiency
+ *
+ * \since QGIS 3.16
+ */
+class CORE_EXPORT QgsMeshMemoryDatasetGroup: public QgsMeshDatasetGroup
+{
+  public:
+    //! Constructor
+    QgsMeshMemoryDatasetGroup() = default;
+    //! Constructor with the \a name of the group
+    QgsMeshMemoryDatasetGroup( const QString &name );
+    //! Constructor with the \a name of the group and the type of data \a dataType
+    QgsMeshMemoryDatasetGroup( const QString &name, QgsMeshDatasetGroupMetadata::DataType dataType );
+
+    void initialize() override;
+    int datasetCount() const override;
+    QgsMeshDatasetMetadata datasetMetadata( int datasetIndex ) const override;
+    QgsMeshDataset *dataset( int index ) const override;
+    virtual QgsMeshDatasetGroup::Type type() const override {return QgsMeshDatasetGroup::Memory;}
+
+    //! Returns a invalid DOM element
+    QDomElement writeXml( QDomDocument &doc, const QgsReadWriteContext &context )  const override;
+
+    //! Adds a memory dataset to the group
+    void addDataset( std::shared_ptr<QgsMeshMemoryDataset> dataset );
+
+    //! Removes all the datasets from the group
+    void clearDatasets();
+
+    //! Returns the dataset with \a index
+    std::shared_ptr<const QgsMeshMemoryDataset> constDataset( int index ) const;
+
+    //! Contains all the memory datasets
+    QVector<std::shared_ptr<QgsMeshMemoryDataset>> memoryDatasets;
+};
+
+#endif //SIP_RUN
+
 /**
  * \ingroup core
  *
@@ -549,25 +774,14 @@ class CORE_EXPORT QgsMeshDatasetMetadata
  *     Minimum
  *     Maximum
  *
+ * Tree items handle also the dependencies between dataset groups represented by these items
+ *
  * \since QGIS 3.14 in core API
  */
 
 class CORE_EXPORT QgsMeshDatasetGroupTreeItem
 {
   public:
-
-    /**
-     * Where the dataset group is stored
-     *
-     * \since QGIS 3.16
-     */
-    enum StorageType
-    {
-      None, //! Generic item that do not store dataset
-      File, //! Dataset group store on file
-      Memory, //! Temporary dataset group in memory
-      OnTheFly //! Dataset group which id based on expression evamluted in real-time
-    };
 
     /**
      * Constructor for an empty dataset group tree item
@@ -578,11 +792,12 @@ class CORE_EXPORT QgsMeshDatasetGroupTreeItem
      * Constructor
      *
      * \param defaultName the name that will be used to display the item if iot not overrides (\see setName())
+     * \param sourceName the name used by the source (provider, dataset group store,...)
      * \param isVector whether the dataset group is a vector dataset group
      * \param index index of the dataset group
      */
     QgsMeshDatasetGroupTreeItem( const QString &defaultName,
-                                 const QString &providerName,
+                                 const QString &sourceName,
                                  bool isVector,
                                  int index );
 
@@ -716,22 +931,47 @@ class CORE_EXPORT QgsMeshDatasetGroupTreeItem
     QString defaultName() const;
 
     /**
-     * \return where the dataset group is stored
+     * \return the dataset group type
      *
      * \since QGIS 3.16
      */
-    QgsMeshDatasetGroupTreeItem::StorageType storageType() const;
+    QgsMeshDatasetGroup::Type datasetGroupType() const;
 
     /**
-     * Sets where the dataset is stored
-     * \param storeType the type of storing
+     * Returns a list of group index corresponding to dataset group that depends on the dataset group represented by this item
+     *
+     * \return list of group index
+     *
+     */
+    QList<int> groupIndexDependencies() const;
+
+    /**
+     * Returns description about the dataset group (URI, formula,...)
      *
      * \since QGIS 3.16
      */
-    void setStorageType( QgsMeshDatasetGroupTreeItem::StorageType storageType );
+    QString description() const;
 
     /**
-     * Write the item and its children in a DOM document
+     * Set parameters of the item in accordance with the dataset group
+     *
+     * \param datasetGroup pointer to the dataset group to accord with
+     *
+     * \since QGIS 3.16
+     */
+    void setDatasetGroup( QgsMeshDatasetGroup *datasetGroup );
+
+    /**
+     * Set parameters of the item in accordance with the persistent dataset group with \a uri
+     *
+     * \param uri uri of the persistant dataset group
+     *
+     * \since QGIS 3.16
+     */
+    void setPersistentDatasetGroup( const QString &uri );
+
+    /**
+     * Writes the item and its children in a DOM document
      * \param doc the DOM document
      * \param context writing context (e.g. for conversion between relative and absolute paths)
      * \return the dom element where the item is written
@@ -746,198 +986,21 @@ class CORE_EXPORT QgsMeshDatasetGroupTreeItem
     // Data
     QString mUserName;
     QString mOriginalName;
-    QString mProviderName;
-    StorageType mStoreType = None;
+    QString mSourceName;
+    QgsMeshDatasetGroup::Type mDatasetGroupType = QgsMeshDatasetGroup::None;
+    QString mDescription;
+
     bool mIsVector = false;
     int mDatasetGroupIndex = -1;
     bool mIsEnabled = true;
+
+    QList<int> mDatasetGroupDependencies;
+    QList<int> mDatasetGroupDependentOn;
+
+    QgsMeshDatasetGroupTreeItem *searchItemBySourceName( const QString &sourceName ) const;
+    QgsMeshDatasetGroupTreeItem *rootItem() const;
+    void freeAsDependency();
+    void freeFromDependencies();
 };
-
-#ifndef SIP_RUN
-
-/**
- * \ingroup core
- *
- * Abstract class that represents a dataset
- *
- * \since QGIS 3.16
- */
-class CORE_EXPORT QgsMeshDataset
-{
-  public:
-    //! Constructor
-    QgsMeshDataset() = default;
-
-    //! Destructor
-    virtual ~QgsMeshDataset() = default;
-
-    //! Returns the value with index \a valueIndex
-    virtual QgsMeshDatasetValue datasetValue( int valueIndex ) const = 0;
-
-    //! Returns \a count values from \a valueIndex
-    virtual QgsMeshDataBlock datasetValues( bool isScalar, int valueIndex, int count ) const = 0;
-
-    //! Returns whether faces are active
-    virtual QgsMeshDataBlock areFacesActive( int faceIndex, int count ) const = 0;
-
-    //! Returns whether the face is active
-    virtual bool isActive( int faceIndex ) const = 0;
-
-    //! Returns the metadata of the dataset
-    virtual QgsMeshDatasetMetadata metaData() const = 0;
-
-    //! Calculates minimum and maximum of the dataset
-    virtual void calculateMinMax() = 0;
-
-    //! Returns the values count
-    virtual int valuesCount() const = 0;
-};
-
-/**
- * \ingroup core
- *
- * Class to store memory dataset
- * The QgsMeshDatasetValue objects and whether the faces are active are stored in QVector containers that are exposed for efficiency
- *
- * \since QGIS 3.16
- */
-class CORE_EXPORT QgsMeshMemoryDataset: public QgsMeshDataset
-{
-  public:
-    //! Constructor
-    QgsMeshMemoryDataset() = default;
-
-    QgsMeshDatasetValue datasetValue( int valueIndex ) const override;
-    QgsMeshDataBlock datasetValues( bool isScalar, int valueIndex, int count ) const override;
-    QgsMeshDataBlock areFacesActive( int faceIndex, int count ) const override;
-    QgsMeshDatasetMetadata metaData() const override;
-    void calculateMinMax() override;
-    bool isActive( int faceIndex ) const override;
-    int valuesCount() const override;
-
-    QVector<QgsMeshDatasetValue> values;
-    QVector<int> active;
-    double time = -1;
-    bool valid = false;
-    double minimum = std::numeric_limits<double>::quiet_NaN();
-    double maximum = std::numeric_limits<double>::quiet_NaN();
-};
-
-/**
- * \ingroup core
- *
- * Abstract class that represents a dataset group
- *
- * \since QGIS 3.16
- */
-class CORE_EXPORT QgsMeshDatasetGroup
-{
-  public:
-    //! Default constructor
-    QgsMeshDatasetGroup() = default;
-    virtual ~QgsMeshDatasetGroup() = default;
-
-    //! Constructor with the \a name of the dataset group
-    QgsMeshDatasetGroup( const QString &name );
-
-    //! Constructor with the \a name of the dataset group and the \a dataTYpe
-    QgsMeshDatasetGroup( const QString &name, QgsMeshDatasetGroupMetadata::DataType dataType );
-
-    //! Returns the metadata of the dataset group
-    virtual QgsMeshDatasetGroupMetadata groupMetadata() const;
-
-    //! Returns the metadata of the dataset with index \a datasetIndex
-    virtual QgsMeshDatasetMetadata datasetMetadata( int datasetIndex ) = 0;
-
-    //! Returns the count of datasets in the group
-    virtual int datasetCount() const = 0;
-
-    //! Returns the dataset with \a index
-    virtual const QgsMeshDataset *dataset( int index ) const = 0;
-
-    //! Returns the minimum value of the whole dataset group
-    double minimum() const;
-
-    //! Returns the maximum value of the whole dataset group
-    double maximum() const;
-
-    //! Overrides the minimum and the maximum value of the whole dataset group
-    void setMinimumMaximum( double min, double max );
-
-    //! Returns the name of the dataset group
-    QString name() const;
-
-    //! Sets the name of the dataset group
-    void setName( const QString &name );
-
-    //! Returns the data type of the dataset group
-    QgsMeshDatasetGroupMetadata::DataType dataType() const;
-
-    //! Sets the data type of the dataset group
-    void setDataType( const QgsMeshDatasetGroupMetadata::DataType &dataType );
-
-    //! Adds extra metadata to the group
-    void addExtraMetadata( QString key, QString value );
-    //! Returns all the extra metadata of the group
-    QMap<QString, QString> extraMetadata() const;
-
-    //! Returns whether the group contain scalar values
-    bool isScalar() const;
-
-    //! Sets whether the group contain scalar values
-    void setIsScalar( bool isScalar );
-
-    //! Returns whether all the datasets contain \a count values
-    bool checkValueCountPerDataset( int count ) const;
-
-  protected:
-    QString mName;
-    double mMinimum = std::numeric_limits<double>::quiet_NaN();
-    double mMaximum = std::numeric_limits<double>::quiet_NaN();
-    QgsMeshDatasetGroupMetadata::DataType mDataType = QgsMeshDatasetGroupMetadata::DataOnVertices;
-    QMap<QString, QString> mMetadata;
-    bool mIsScalar = true;
-};
-
-/**
- * \ingroup core
- *
- * Class that represents a dataset group stored in memory
- * The QgsMeshMemoryDataset objects stores in a QVector container that are exposed for efficiency
- *
- * \since QGIS 3.16
- */
-class CORE_EXPORT QgsMeshMemoryDatasetGroup: public QgsMeshDatasetGroup
-{
-  public:
-    //! Constructor
-    QgsMeshMemoryDatasetGroup() = default;
-    //! Constructor with the \a name of the group
-    QgsMeshMemoryDatasetGroup( const QString &name );
-    //! Constructor with the \a name of the group and the type of data \a dataType
-    QgsMeshMemoryDatasetGroup( const QString &name, QgsMeshDatasetGroupMetadata::DataType dataType );
-
-    int datasetCount() const override;
-    QgsMeshDatasetMetadata datasetMetadata( int datasetIndex ) override;
-    const QgsMeshDataset *dataset( int index ) const override;
-
-    //! Adds a memory dataset to the group
-    void addDataset( std::shared_ptr<QgsMeshMemoryDataset> dataset );
-
-    //! Removes all the datasets from the group
-    void clearDatasets();
-
-    //! Returns the dataset with \a index
-    std::shared_ptr<const QgsMeshMemoryDataset> constDataset( int index ) const;
-
-    //! Calculates the statictics (minimum and maximum)
-    void calculateStatistic();
-
-    //! Contains all the memory datasets
-    QVector<std::shared_ptr<QgsMeshMemoryDataset>> memoryDatasets;
-
-};
-
-#endif //SIP_RUN
 
 #endif // QGSMESHDATASET_H

--- a/src/core/mesh/qgsmeshdatasetgroupstore.cpp
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.cpp
@@ -16,7 +16,10 @@
  ***************************************************************************/
 
 #include "qgsmeshdatasetgroupstore.h"
+#include "qgsmeshlayer.h"
 #include "qgsmeshlayerutils.h"
+#include "qgsapplication.h"
+#include "qgsmeshdatagenerator.h"
 
 
 QList<int> QgsMeshDatasetGroupStore::datasetGroupIndexes() const
@@ -34,7 +37,8 @@ int QgsMeshDatasetGroupStore::extraDatasetGroupCount() const
   return mExtraDatasets->datasetGroupCount();
 }
 
-QgsMeshDatasetGroupStore::QgsMeshDatasetGroupStore():
+QgsMeshDatasetGroupStore::QgsMeshDatasetGroupStore( QgsMeshLayer *layer ):
+  mLayer( layer ),
   mExtraDatasets( new QgsMeshExtraDatasetStore ),
   mDatasetGroupTreeRootItem( new QgsMeshDatasetGroupTreeItem )
 {}
@@ -66,7 +70,7 @@ bool QgsMeshDatasetGroupStore::addPersistentDatasets( const QString &path )
 
 bool QgsMeshDatasetGroupStore::addDatasetGroup( QgsMeshDatasetGroup *group )
 {
-  if ( !mPersistentProvider && mExtraDatasets )
+  if ( !mPersistentProvider || !mExtraDatasets )
     return false;
 
   switch ( group->dataType() )
@@ -88,11 +92,12 @@ bool QgsMeshDatasetGroupStore::addDatasetGroup( QgsMeshDatasetGroup *group )
       break;
   }
 
-  mExtraDatasets->addDatasetGroup( group );
+  int nativeIndex = mExtraDatasets->addDatasetGroup( group );
+  int groupIndex = registerDatasetGroup( DatasetGroup{mExtraDatasets.get(), nativeIndex} );
   QList<int> groupIndexes;
-  groupIndexes.append( registerDatasetGroup( DatasetGroup{mExtraDatasets.get(), mExtraDatasets->datasetGroupCount() - 1} ) );
-
+  groupIndexes.append( groupIndex );
   createDatasetGroupTreeItems( groupIndexes );
+  syncItemToDatasetGroup( groupIndex );
 
   emit datasetGroupsAdded( groupIndexes );
 
@@ -103,6 +108,9 @@ void QgsMeshDatasetGroupStore::resetDatasetGroupTreeItem()
 {
   mDatasetGroupTreeRootItem.reset( new QgsMeshDatasetGroupTreeItem );
   createDatasetGroupTreeItems( datasetGroupIndexes() );
+  QList<int> groupIndexes = datasetGroupIndexes();
+  for ( int groupIndex : groupIndexes )
+    syncItemToDatasetGroup( groupIndex );
 }
 
 QgsMeshDatasetGroupTreeItem *QgsMeshDatasetGroupStore::datasetGroupTreeItem() const
@@ -193,7 +201,7 @@ bool QgsMeshDatasetGroupStore::isFaceActive( const QgsMeshDatasetIndex &index, i
 }
 
 QgsMeshDatasetIndex QgsMeshDatasetGroupStore::datasetIndexAtTime(
-  quint64 time,
+  qint64 time,
   int groupIndex, QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod method ) const
 {
   QgsMeshDatasetGroupStore::DatasetGroup  group = datasetGroup( groupIndex );
@@ -206,7 +214,7 @@ QgsMeshDatasetIndex QgsMeshDatasetGroupStore::datasetIndexAtTime(
                               group.first->datasetIndexAtTime( referenceTime, group.second, time, method ).dataset() );
 }
 
-quint64 QgsMeshDatasetGroupStore::datasetRelativeTime( const QgsMeshDatasetIndex &index ) const
+qint64 QgsMeshDatasetGroupStore::datasetRelativeTime( const QgsMeshDatasetIndex &index ) const
 {
   QgsMeshDatasetGroupStore::DatasetGroup  group = datasetGroup( index.group() );
   if ( !group.first || group.second < 0 )
@@ -238,14 +246,28 @@ QDomElement QgsMeshDatasetGroupStore::writeXml( QDomDocument &doc, const QgsRead
   QMap < int, DatasetGroup>::const_iterator it = mRegistery.begin();
   while ( it != mRegistery.end() )
   {
-    QDomElement elemDataset = doc.createElement( QStringLiteral( "mesh-dataset" ) );
-    elemDataset.setAttribute( QStringLiteral( "global-index" ), it.key() );
+    QDomElement elemDataset;
     if ( it.value().first == mPersistentProvider )
     {
+      elemDataset = doc.createElement( QStringLiteral( "mesh-dataset" ) );
+      elemDataset.setAttribute( QStringLiteral( "global-index" ), it.key() );
       elemDataset.setAttribute( QStringLiteral( "source-type" ), QStringLiteral( "persitent-provider" ) );
       elemDataset.setAttribute( QStringLiteral( "source-index" ), it.value().second );
-      storeElement.appendChild( elemDataset );
+
     }
+    else if ( it.value().first == mExtraDatasets.get() )
+    {
+      QgsMeshDatasetGroupTreeItem *item = mDatasetGroupTreeRootItem->childFromDatasetGroupIndex( it.key() );
+      if ( item )
+      {
+        elemDataset = mExtraDatasets->writeXml( it.value().second, doc, context );
+        if ( !elemDataset.isNull() )
+          elemDataset.setAttribute( QStringLiteral( "global-index" ), it.key() );
+      }
+    }
+
+    if ( !elemDataset.isNull() )
+      storeElement.appendChild( elemDataset );
     ++it;
   }
 
@@ -257,13 +279,37 @@ void QgsMeshDatasetGroupStore::readXml( const QDomElement &storeElem, const QgsR
   Q_UNUSED( context );
   mRegistery.clear();
   QDomElement datasetElem = storeElem.firstChildElement( "mesh-dataset" );
+  QMap<int, QgsMeshDatasetGroup *> extraDatasetGroups;
   while ( !datasetElem.isNull() )
   {
     int globalIndex = datasetElem.attribute( QStringLiteral( "global-index" ) ).toInt();
-    int sourceIndex = datasetElem.attribute( QStringLiteral( "source-index" ) ).toInt();
+    int sourceIndex;
     QgsMeshDatasetSourceInterface *source = nullptr;
     if ( datasetElem.attribute( QStringLiteral( "source-type" ) ) == QStringLiteral( "persitent-provider" ) )
+    {
       source = mPersistentProvider;
+      sourceIndex = datasetElem.attribute( QStringLiteral( "source-index" ) ).toInt();
+    }
+    else
+    {
+      QString keyGenerator = datasetElem.attribute( QStringLiteral( "source-type" ) );
+      source = mExtraDatasets.get();
+      QString name = datasetElem.attribute( QStringLiteral( "name" ) );
+      QString formula = datasetElem.attribute( QStringLiteral( "formula" ) );
+      qint64 startTime = datasetElem.attribute( QStringLiteral( "startTime" ) ).toLongLong();
+      qint64 endTime = datasetElem.attribute( QStringLiteral( "endTime" ) ).toLongLong();
+      if ( QgsApplication::instance() )
+      {
+        QgsMeshDataGeneratorInterface *generator =
+          QgsApplication::instance()->meshDataGeneratorRegistry()->meshDataGenerator( keyGenerator );
+        if ( generator )
+        {
+          QgsMeshDatasetGroup *dsg = generator->createVirtualDatasetGroupFromFormula( name, formula, mLayer, startTime, endTime );
+          extraDatasetGroups[globalIndex] = dsg;
+          sourceIndex = mExtraDatasets->addDatasetGroup( dsg );
+        }
+      }
+    }
 
     if ( source )
       mRegistery[globalIndex] = DatasetGroup{source, sourceIndex};
@@ -277,6 +323,13 @@ void QgsMeshDatasetGroupStore::readXml( const QDomElement &storeElem, const QgsR
 
   checkDatasetConsistency( mPersistentProvider );
   removeUnregisteredItemFromTree();
+
+  //Once everything is created, initialize the extra dataset groups
+  for ( int groupIndex : extraDatasetGroups.keys() )
+    extraDatasetGroups.value( groupIndex )->initialize();
+
+
+  mExtraDatasets->updateTemporalCapabilities();
 }
 
 bool QgsMeshDatasetGroupStore::saveDatasetGroup( QString filePath, int groupIndex, QString driver )
@@ -298,7 +351,7 @@ bool QgsMeshDatasetGroupStore::saveDatasetGroup( QString filePath, int groupInde
     {
       QgsMeshDatasetGroupTreeItem *item = mDatasetGroupTreeRootItem->childFromDatasetGroupIndex( groupIndex );
       if ( item )
-        item->setStorageType( QgsMeshDatasetGroupTreeItem::File );
+        item->setPersistentDatasetGroup( filePath );
     }
   }
 
@@ -316,6 +369,9 @@ void QgsMeshDatasetGroupStore::onPersistentDatasetAdded( int count )
     groupIndexes.append( registerDatasetGroup( DatasetGroup{mPersistentProvider, i} ) );
 
   createDatasetGroupTreeItems( groupIndexes );
+  for ( int groupIndex : groupIndexes )
+    syncItemToDatasetGroup( groupIndex );
+
   emit datasetGroupsAdded( groupIndexes );
 }
 
@@ -403,6 +459,8 @@ void QgsMeshDatasetGroupStore::checkDatasetConsistency( QgsMeshDatasetSourceInte
 
   if ( !indexes.isEmpty() )
     createDatasetGroupTreeItems( indexes );
+  for ( int index : indexes )
+    syncItemToDatasetGroup( index );
 }
 
 void QgsMeshDatasetGroupStore::removeUnregisteredItemFromTree()
@@ -454,6 +512,25 @@ void QgsMeshDatasetGroupStore::unregisterGroupNotPresentInTree()
   }
 }
 
+void QgsMeshDatasetGroupStore::syncItemToDatasetGroup( int groupIndex )
+{
+  if ( !mDatasetGroupTreeRootItem )
+    return;
+  DatasetGroup group = datasetGroup( groupIndex );
+  QgsMeshDatasetGroupTreeItem *item = mDatasetGroupTreeRootItem->childFromDatasetGroupIndex( groupIndex );
+  if ( group.first == mPersistentProvider && mPersistentProvider )
+  {
+    QgsMeshDatasetGroupMetadata meta = mPersistentProvider->datasetGroupMetadata( group.second );
+    if ( item )
+      item->setPersistentDatasetGroup( meta.uri() );
+  }
+  else if ( group.first == mExtraDatasets.get() )
+  {
+    if ( item )
+      item->setDatasetGroup( mExtraDatasets->datasetGroup( group.second ) );
+  }
+}
+
 void QgsMeshDatasetGroupStore::createDatasetGroupTreeItems( const QList<int> &indexes )
 {
   QMap<QString, QgsMeshDatasetGroupTreeItem *> mNameToItem;
@@ -487,22 +564,10 @@ void QgsMeshDatasetGroupStore::createDatasetGroupTreeItems( const QList<int> &in
     if ( mNameToItem.contains( name ) )
       QgsDebugMsg( QStringLiteral( "Group %1 is not unique" ).arg( displayName ) );
     mNameToItem[name] = item;
-
-    DatasetGroup group = datasetGroup( groupIndex );
-    QgsMeshDatasetGroupTreeItem::StorageType type;
-    if ( group.first == mPersistentProvider )
-      type = QgsMeshDatasetGroupTreeItem::File;
-    else if ( group.first == mExtraDatasets.get() )
-      type = QgsMeshDatasetGroupTreeItem::Memory;
-    else
-      type = QgsMeshDatasetGroupTreeItem::None;
-
-    item->setStorageType( type );
-
   }
 }
 
-void QgsMeshExtraDatasetStore::addDatasetGroup( QgsMeshDatasetGroup *datasetGroup )
+int QgsMeshExtraDatasetStore::addDatasetGroup( QgsMeshDatasetGroup *datasetGroup )
 {
   int groupIndex = mGroups.size();
   mGroups.push_back( std::unique_ptr<QgsMeshDatasetGroup>( datasetGroup ) );
@@ -511,8 +576,10 @@ void QgsMeshExtraDatasetStore::addDatasetGroup( QgsMeshDatasetGroup *datasetGrou
   {
     mTemporalCapabilities->setHasTemporalCapabilities( true );
     for ( int i = 0; i < datasetGroup->datasetCount(); ++i )
-      mTemporalCapabilities->addDatasetTime( groupIndex, datasetGroup->dataset( i )->metaData().time() );
+      mTemporalCapabilities->addDatasetTime( groupIndex, datasetGroup->datasetMetadata( i ).time() );
   }
+
+  return mGroups.size() - 1;
 }
 
 void QgsMeshExtraDatasetStore::removeDatasetGroup( int index )
@@ -520,20 +587,8 @@ void QgsMeshExtraDatasetStore::removeDatasetGroup( int index )
   if ( index < datasetGroupCount() )
     mGroups.erase( mGroups.begin() + index );
 
-  //update temporal capabilitie
-  mTemporalCapabilities->clear();
-  bool hasTemporal = false;
-  for ( size_t g = 0; g < mGroups.size(); ++g )
-  {
-    const QgsMeshDatasetGroup *group = mGroups[g].get();
-    hasTemporal |= group->datasetCount() > 1;
-    for ( int i = 0; i < group->datasetCount(); ++i )
-      mTemporalCapabilities->addDatasetTime( index, group->dataset( i )->metaData().time() );
-  }
 
-
-
-  mTemporalCapabilities->setHasTemporalCapabilities( hasTemporal );
+  updateTemporalCapabilities();
 }
 
 bool QgsMeshExtraDatasetStore::hasTemporalCapabilities() const
@@ -544,6 +599,22 @@ bool QgsMeshExtraDatasetStore::hasTemporalCapabilities() const
 quint64 QgsMeshExtraDatasetStore::datasetRelativeTime( QgsMeshDatasetIndex index )
 {
   return mTemporalCapabilities->datasetTime( index );
+}
+
+QString QgsMeshExtraDatasetStore::description( int groupIndex ) const
+{
+  if ( groupIndex >= 0 && groupIndex < int( mGroups.size() ) )
+    return mGroups.at( groupIndex )->description();
+  else
+    return QString();
+}
+
+QgsMeshDatasetGroup *QgsMeshExtraDatasetStore::datasetGroup( int groupIndex ) const
+{
+  if ( groupIndex >= 0 && groupIndex < int( mGroups.size() ) )
+    return mGroups[groupIndex].get();
+  else
+    return nullptr;
 }
 
 bool QgsMeshExtraDatasetStore::addDataset( const QString &uri )
@@ -586,7 +657,7 @@ QgsMeshDatasetMetadata QgsMeshExtraDatasetStore::datasetMetadata( QgsMeshDataset
     int datasetIndex = index.dataset();
     const QgsMeshDatasetGroup *group = mGroups.at( groupIndex ).get();
     if ( datasetIndex < group->datasetCount() )
-      return group->dataset( datasetIndex )->metaData();
+      return group->datasetMetadata( datasetIndex );
   }
   return QgsMeshDatasetMetadata();
 }
@@ -681,4 +752,28 @@ bool QgsMeshExtraDatasetStore::persistDatasetGroup( const QString &outputFilePat
   Q_UNUSED( source )
   Q_UNUSED( datasetGroupIndex )
   return true; // not implemented/supported
+}
+
+QDomElement QgsMeshExtraDatasetStore::writeXml( int groupIndex, QDomDocument &doc, const QgsReadWriteContext &context )
+{
+  if ( groupIndex >= 0 && groupIndex < int( mGroups.size() ) && mGroups[groupIndex] )
+    return mGroups[groupIndex]->writeXml( doc, context );
+  else
+    return QDomElement();
+}
+
+void QgsMeshExtraDatasetStore::updateTemporalCapabilities()
+{
+  //update temporal capabilitie
+  mTemporalCapabilities->clear();
+  bool hasTemporal = false;
+  for ( size_t g = 0; g < mGroups.size(); ++g )
+  {
+    const QgsMeshDatasetGroup *group = mGroups[g].get();
+    hasTemporal |= group->datasetCount() > 1;
+    for ( int i = 0; i < group->datasetCount(); ++i )
+      mTemporalCapabilities->addDatasetTime( g, group->datasetMetadata( i ).time() );
+  }
+
+  mTemporalCapabilities->setHasTemporalCapabilities( hasTemporal );
 }

--- a/src/core/mesh/qgsmeshdatasetgroupstore.h
+++ b/src/core/mesh/qgsmeshdatasetgroupstore.h
@@ -23,6 +23,8 @@
 #include "qgsmeshdataprovider.h"
 #include "qgsmeshdataset.h"
 
+class QgsMeshLayer;
+
 /**
  * \ingroup core
  *
@@ -35,8 +37,8 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
 {
   public:
 
-    //! Adds a dataset group
-    void addDatasetGroup( QgsMeshDatasetGroup *datasetGroup );
+    //! Adds a dataset group, returns the index of the added dataset group
+    int addDatasetGroup( QgsMeshDatasetGroup *datasetGroup );
 
     //! Removes the dataset group with the local \a index
     void removeDatasetGroup( int index );
@@ -46,6 +48,12 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
 
     //! Returns the relative times of the dataset index with \a index, returned value in miliseconds
     quint64 datasetRelativeTime( QgsMeshDatasetIndex index );
+
+    //! Returns information related to the dataset group with \a groupIndex
+    QString description( int groupIndex ) const;
+
+    //! Returns a pointer to the dataset group
+    QgsMeshDatasetGroup *datasetGroup( int groupIndex ) const;
 
     int datasetGroupCount() const override;
     int datasetCount( int groupIndex ) const override;
@@ -77,6 +85,11 @@ class QgsMeshExtraDatasetStore: public QgsMeshDatasetSourceInterface
                               QgsMeshDatasetSourceInterface *source,
                               int datasetGroupIndex ) override;
 
+    //! Writes the store's information in a DOM document
+    QDomElement writeXml( int groupIndex, QDomDocument &doc, const QgsReadWriteContext &context );
+
+    //! Updates the temporal capabilities
+    void updateTemporalCapabilities();
 
   private:
     std::vector<std::unique_ptr<QgsMeshDatasetGroup>> mGroups;
@@ -112,7 +125,7 @@ class QgsMeshDatasetGroupStore: public QObject
 
   public:
     //! Constructor
-    QgsMeshDatasetGroupStore();
+    QgsMeshDatasetGroupStore( QgsMeshLayer *layer );
 
     //! Sets the persistent mesh data provider
     void setPersistentProvider( QgsMeshDataProvider *provider );
@@ -174,14 +187,14 @@ class QgsMeshDatasetGroupStore: public QObject
     bool isFaceActive( const QgsMeshDatasetIndex &index, int faceIndex ) const;
 
     //! Returns the global dataset index of the dataset int the dataset group with \a groupIndex, corresponding to the relative \a time and the check \a method
-    QgsMeshDatasetIndex datasetIndexAtTime( quint64 time,
+    QgsMeshDatasetIndex datasetIndexAtTime( qint64 time,
                                             int groupIndex,
                                             QgsMeshDataProviderTemporalCapabilities::MatchingTemporalDatasetMethod method ) const;
 
     //! Returns the relative time of the dataset from the persistent provider reference time
-    quint64 datasetRelativeTime( const QgsMeshDatasetIndex &index ) const;
+    qint64 datasetRelativeTime( const QgsMeshDatasetIndex &index ) const;
 
-    //! Returns wether at lea&st one of stored dataset group is temporal
+    //! Returns wether at least one of stored dataset group is temporal
     bool hasTemporalCapabilities() const;
 
     //! Writes the store's information in a DOM document
@@ -198,7 +211,7 @@ class QgsMeshDatasetGroupStore: public QObject
     void onPersistentDatasetAdded( int count );
 
   private:
-
+    QgsMeshLayer *mLayer = nullptr;
     QgsMeshDataProvider *mPersistentProvider = nullptr;
     std::unique_ptr<QgsMeshExtraDatasetStore> mExtraDatasets;
     QMap < int, DatasetGroup> mRegistery;
@@ -222,6 +235,8 @@ class QgsMeshDatasetGroupStore: public QObject
     void checkDatasetConsistency( QgsMeshDatasetSourceInterface *source );
     void removeUnregisteredItemFromTree();
     void unregisterGroupNotPresentInTree();
+
+    void syncItemToDatasetGroup( int groupIndex );
 };
 
 #endif // QGSMESHDATASETGROUPSTORE_H

--- a/src/core/mesh/qgsmeshlayer.h
+++ b/src/core/mesh/qgsmeshlayer.h
@@ -170,7 +170,6 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     QgsMapLayerTemporalProperties *temporalProperties() override;
     void reload() override;
     QStringList subLayers() const override;
-    bool isTemporary() const override;
 
     //! Returns the provider type for this layer
     QString providerType() const;
@@ -194,7 +193,7 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
      *
      * \since QGIS 3.16
      */
-    bool addDatasets( QgsMeshDatasetGroup *datasetGroup )SIP_SKIP;
+    bool addDatasets( QgsMeshDatasetGroup *datasetGroup ) SIP_SKIP;
 
     /**
      * Saves datasets group on file with the specified \a driver
@@ -497,10 +496,9 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       */
     QgsMeshDatasetValue dataset1dValue( const QgsMeshDatasetIndex &index, const QgsPointXY &point, double searchRadius ) const;
 
-
     /**
       * Returns dataset index from datasets group depending on the time range.
-      * If the temporal properties is not active, returns invalid dataset index
+      * If the temporal properties is not active, returns invalid dataset index. This method is used for rendering mesh layer.
       *
       * \param timeRange the time range
       * \returns dataset index
@@ -513,6 +511,22 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
       * \since QGIS 3.14
       */
     QgsMeshDatasetIndex datasetIndexAtTime( const QgsDateTimeRange &timeRange, int datasetGroupIndex ) const;
+
+    /**
+      * Returns dataset index from datasets group depending on the relative time from the layer reference time.
+      * Dataset index is valid even the temporal properties is inactive. This method is used for calculation on mesh layer.
+      *
+      * \param relativeTime the relative from the mesh layer reference time
+      * \returns dataset index
+      *
+      * \note the returned dataset index depends on the matching method, see setTemporalMatchingMethod()
+      *
+      * \note indexes are used to distinguish all the dataset groups handled by the layer (from dataprovider, extra dataset group,...)
+      * In the layer scope, those indexes are different from the data provider indexes.
+      *
+      * \since QGIS 3.16
+      */
+    QgsMeshDatasetIndex datasetIndexAtRelativeTime( const QgsInterval &relativeTime, int datasetGroupIndex ) const;
 
     /**
       * Returns dataset index from active scalar group depending on the time range.
@@ -652,11 +666,18 @@ class CORE_EXPORT QgsMeshLayer : public QgsMapLayer
     QgsInterval firstValidTimeStep() const;
 
     /**
-     * Returns the relative time (in milliseconds) of the dataset from the reference time of its group
+     * Returns the relative time of the dataset from the reference time of its group
      *
      * \since QGIS 3.16
      */
     QgsInterval datasetRelativeTime( const QgsMeshDatasetIndex &index );
+
+    /**
+     * Returns the relative time (in milliseconds) of the dataset from the reference time of its group
+     *
+     * \since QGIS 3.16
+     */
+    qint64 datasetRelativeTimeInMilliseconds( const QgsMeshDatasetIndex &index );
 
   public slots:
 

--- a/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
+++ b/src/core/providers/meshmemory/qgsmeshmemorydataprovider.cpp
@@ -190,7 +190,7 @@ bool QgsMeshMemoryDataProvider::splitDatasetSections( const QString &uri, QgsMes
     if ( success )
       success = checkDatasetValidity( dataset, datasetGroup.dataType() );
     if ( success )
-      datasetGroup.memoryDatasets.push_back( dataset );
+      datasetGroup.addDataset( dataset );
   }
 
   return success;

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -63,6 +63,8 @@
 #include "qgsstylemodel.h"
 #include "qgsconnectionregistry.h"
 #include "qgsremappingproxyfeaturesink.h"
+#include "qgsmeshlayer.h"
+#include "qgsmeshdatagenerator.h"
 
 #include "gps/qgsgpsconnectionregistry.h"
 #include "processing/qgsprocessingregistry.h"
@@ -2241,6 +2243,11 @@ QgsLocalizedDataPathRegistry *QgsApplication::localizedDataPathRegistry()
   return members()->mLocalizedDataPathRegistry;
 }
 
+QgsMeshDataGeneratorRegistry *QgsApplication::meshDataGeneratorRegistry()
+{
+  return members()->mMeshDataGeneratorRegistry;
+}
+
 QgsApplication::ApplicationMembers::ApplicationMembers()
 {
   // don't use initializer lists or scoped pointers - as more objects are added here we
@@ -2367,6 +2374,11 @@ QgsApplication::ApplicationMembers::ApplicationMembers()
     profiler->end();
   }
   {
+    profiler->start( tr( "Setup mesh data generator registry" ) );
+    mMeshDataGeneratorRegistry = new QgsMeshDataGeneratorRegistry();
+    profiler->end();
+  }
+  {
     profiler->start( tr( "Setup bookmark manager" ) );
     mBookmarkManager = new QgsBookmarkManager( nullptr );
     profiler->end();
@@ -2409,6 +2421,7 @@ QgsApplication::ApplicationMembers::~ApplicationMembers()
   delete mBookmarkManager;
   delete mConnectionRegistry;
   delete mLocalizedDataPathRegistry;
+  delete mMeshDataGeneratorRegistry;
 }
 
 QgsApplication::ApplicationMembers *QgsApplication::members()

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -59,6 +59,7 @@ class QgsStyleModel;
 class QgsNumericFormatRegistry;
 class QgsConnectionRegistry;
 class QgsScaleBarRendererRegistry;
+class QgsMeshDataGeneratorRegistry;
 
 /**
  * \ingroup core
@@ -800,6 +801,14 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QgsLocalizedDataPathRegistry *localizedDataPathRegistry() SIP_KEEPREFERENCE;
 
     /**
+     * Returns the registry of mesh data generators
+     * These are used to generate mesh data as virtual dataset groups
+     *
+     * \since QGIS 3.16
+     */
+    static QgsMeshDataGeneratorRegistry *meshDataGeneratorRegistry() SIP_SKIP;
+
+    /**
      * This string is used to represent the value `NULL` throughout QGIS.
      *
      * In general, when passing values around, prefer to use a null QVariant
@@ -940,6 +949,7 @@ class CORE_EXPORT QgsApplication : public QApplication
       QgsPageSizeRegistry *mPageSizeRegistry = nullptr;
       QgsRasterRendererRegistry *mRasterRendererRegistry = nullptr;
       QgsRendererRegistry *mRendererRegistry = nullptr;
+      QgsMeshDataGeneratorRegistry *mMeshDataGeneratorRegistry = nullptr;
       QgsSvgCache *mSvgCache = nullptr;
       QgsImageCache *mImageCache = nullptr;
       QgsSymbolLayerRegistry *mSymbolLayerRegistry = nullptr;

--- a/src/providers/mdal/qgsmdalprovider.cpp
+++ b/src/providers/mdal/qgsmdalprovider.cpp
@@ -289,6 +289,10 @@ bool QgsMdalProvider::persistDatasetGroup(
     MDAL_G_setMetadata( g, it.key().toStdString().c_str(), it.value().toStdString().c_str() );
   }
 
+  if ( meta.referenceTime().isValid() )
+  {
+    MDAL_G_setReferenceTime( g, meta.referenceTime().toString( Qt::ISODateWithMs ).toStdString().c_str() );
+  }
 
   for ( int i = 0; i < datasetValues.size(); ++i )
   {
@@ -368,6 +372,11 @@ bool QgsMdalProvider::persistDatasetGroup( const QString &outputFilePath, const 
   for ( auto it = extraOptions.cbegin(); it != extraOptions.cend(); ++it )
   {
     MDAL_G_setMetadata( g, it.key().toStdString().c_str(), it.value().toStdString().c_str() );
+  }
+
+  if ( meta.referenceTime().isValid() )
+  {
+    MDAL_G_setReferenceTime( g, meta.referenceTime().toString( Qt::ISODateWithMs ).toStdString().c_str() );
   }
 
   bool fail = false;

--- a/src/ui/mesh/qgsmeshcalculatordialogbase.ui
+++ b/src/ui/mesh/qgsmeshcalculatordialogbase.ui
@@ -40,20 +40,6 @@
        <layout class="QVBoxLayout" name="verticalLayout_4">
         <item>
          <layout class="QGridLayout" name="gridLayout_5">
-          <item row="2" column="0">
-           <widget class="QLabel" name="mOutputFormatLabel">
-            <property name="text">
-             <string>Output Format</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QRadioButton" name="mOutputOnMemoryRadioButton">
-            <property name="text">
-             <string>On Memory</string>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="0">
            <widget class="QLabel" name="mOutputFormatLabel_2">
             <property name="text">
@@ -61,14 +47,12 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1" colspan="2">
-           <widget class="QComboBox" name="mOutputFormatComboBox"/>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
-          </item>
-          <item row="1" column="1" colspan="2">
-           <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
+          <item row="2" column="0">
+           <widget class="QLabel" name="mOutputFormatLabel">
+            <property name="text">
+             <string>Output Format</string>
+            </property>
+           </widget>
           </item>
           <item row="0" column="1">
            <widget class="QRadioButton" name="mOutputOnFileRadioButton">
@@ -80,12 +64,28 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="1" colspan="2">
+           <widget class="QgsFileWidget" name="mOutputDatasetFileWidget" native="true"/>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="mOutputDatasetLabel">
             <property name="text">
              <string>Output Dataset</string>
             </property>
            </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <widget class="QComboBox" name="mOutputFormatComboBox"/>
+          </item>
+          <item row="0" column="2">
+           <widget class="QRadioButton" name="mOutputVirtualRadioButton">
+            <property name="text">
+             <string>Virtual</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QLineEdit" name="mOutputGroupNameLineEdit"/>
           </item>
           <item row="1" column="0">
            <widget class="QLabel" name="label_4">

--- a/src/ui/mesh/qgsmeshdatasetgrouptreewidgetbase.ui
+++ b/src/ui/mesh/qgsmeshdatasetgrouptreewidgetbase.ui
@@ -48,9 +48,6 @@
        <number>0</number>
       </property>
       <item>
-       <widget class="QgsMeshDatasetGroupTreeView" name="mDatasetGroupTreeView"/>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <property name="topMargin">
          <number>0</number>
@@ -186,6 +183,9 @@
          </spacer>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QgsMeshDatasetGroupTreeView" name="mDatasetGroupTreeView"/>
       </item>
      </layout>
     </widget>

--- a/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
+++ b/src/ui/mesh/qgsmeshlayerpropertiesbase.ui
@@ -249,7 +249,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>661</width>
-                <height>507</height>
+                <height>508</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_4">

--- a/tests/src/analysis/testqgsmeshcalculator.cpp
+++ b/tests/src/analysis/testqgsmeshcalculator.cpp
@@ -18,6 +18,7 @@ Email                : zilolv at gmail dot com
 
 #include "qgsmeshcalculator.h"
 #include "qgsmeshcalcnode.h"
+#include "qgsmeshvirtualdatasetgroup.h"
 #include "qgsmeshdataprovider.h"
 #include "qgsmeshlayer.h"
 #include "qgsapplication.h"
@@ -50,6 +51,9 @@ class TestQgsMeshCalculator : public QObject
     void calcWithMixedLayers();
 
     void calcAndSave();
+
+    void virtualDatasetGroup();
+    void test_dataset_group_dependency();
 
   private:
 
@@ -314,6 +318,115 @@ void TestQgsMeshCalculator::calcAndSave()
 
   QFileInfo fileInfo( tempFilePath );
   QVERIFY( fileInfo.exists() );
+}
+
+void TestQgsMeshCalculator::virtualDatasetGroup()
+{
+  QString formula = QStringLiteral( "\"VertexScalarDataset\" + 2" );
+  QgsMeshVirtualDatasetGroup virtualDatasetGroup( "Virtual Dataset group", formula, mpMeshLayer, 0, 10000000 );
+  virtualDatasetGroup.initialize();
+  QCOMPARE( virtualDatasetGroup.datasetCount(), 2 );
+
+  const QgsMeshDataset *dataset = virtualDatasetGroup.dataset( 0 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 3 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 4 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 5 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 4 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 3 );
+
+  dataset = virtualDatasetGroup.dataset( 1 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 4 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 5 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 6 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 5 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 4 );
+
+  formula = QStringLiteral( "\"VertexScalarDataset\" + \"FaceScalarDataset\"" );
+  virtualDatasetGroup = QgsMeshVirtualDatasetGroup( "Virtual Dataset group", formula, mpMeshLayer, 0, 10000000 );
+  virtualDatasetGroup.initialize();
+  QCOMPARE( virtualDatasetGroup.datasetCount(), 2 );
+
+  dataset = virtualDatasetGroup.dataset( 0 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 2 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 3.5 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 5 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 3.5 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 2 );
+
+  dataset = virtualDatasetGroup.dataset( 1 );
+  QCOMPARE( dataset->valuesCount(), 5 );
+  QCOMPARE( dataset->datasetValue( 0 ).scalar(), 4 );
+  QCOMPARE( dataset->datasetValue( 1 ).scalar(), 5.5 );
+  QCOMPARE( dataset->datasetValue( 2 ).scalar(), 7 );
+  QCOMPARE( dataset->datasetValue( 3 ).scalar(), 5.5 );
+  QCOMPARE( dataset->datasetValue( 4 ).scalar(), 4 );
+}
+
+
+void TestQgsMeshCalculator::test_dataset_group_dependency()
+{
+  int vertexCount = mpMeshLayer->dataProvider()->vertexCount();
+  std::vector<std::unique_ptr<QgsMeshMemoryDatasetGroup>> memoryDatasetGroups( 4 );
+  for ( int dsg = 0; dsg < 4; ++dsg )
+  {
+    memoryDatasetGroups[dsg].reset( new QgsMeshMemoryDatasetGroup );
+    memoryDatasetGroups[dsg]->setDataType( QgsMeshDatasetGroupMetadata::DataOnVertices );
+    memoryDatasetGroups[dsg]->setName( QString( "dataset_group_%1" ).arg( dsg ) );
+    for ( int i = 0; i < 10; i++ )
+    {
+      std::shared_ptr<QgsMeshMemoryDataset> ds = std::make_shared<QgsMeshMemoryDataset>();
+      ds->time = i / 3600.0;
+      for ( int v = 0; v < vertexCount; ++v )
+        ds->values.append( QgsMeshDatasetValue( v / 2.0 + dsg ) );
+
+      memoryDatasetGroups[dsg]->addDataset( ds );
+    }
+    mpMeshLayer->addDatasets( memoryDatasetGroups[dsg].release() );
+  }
+
+  QStringList formulas;
+
+  formulas.append( QStringLiteral( "\"dataset_group_0\" + 2" ) );
+  formulas.append( QStringLiteral( "\"dataset_group_3\" + \"virtual_0\"" ) );
+  formulas.append( QStringLiteral( "\"VertexScalarDataset\" + \"FaceScalarDataset\"" ) );
+  formulas.append( QStringLiteral( " max_aggr ( \"VertexScalarDataset\")  + min_aggr(\"FaceScalarDataset\")" ) );
+  formulas.append( QStringLiteral( " max_aggr ( \"VertexScalarDataset\")  + 2" ) );
+  formulas.append( QStringLiteral( " max_aggr ( \"VertexScalarDataset\")  + \"virtual_0\"" ) );
+  formulas.append( QStringLiteral( " \"virtual_0\" + max_aggr ( \"VertexScalarDataset\")  + 1" ) );
+  QVector<int> sizes{10, 10, 2, 1, 1, 10, 10};
+
+  std::vector<std::unique_ptr<QgsMeshVirtualDatasetGroup>> virtualDatasetGroups( formulas.count() );
+
+  for ( int i = 0; i < formulas.count(); ++i )
+  {
+    virtualDatasetGroups[i].reset( new QgsMeshVirtualDatasetGroup( QString( "virtual_%1" ).arg( i ), formulas[i], mpMeshLayer, 0, 100000 ) );
+    virtualDatasetGroups[i]->initialize();
+    QCOMPARE( sizes[i], virtualDatasetGroups[i]->datasetCount() );
+    mpMeshLayer->addDatasets( virtualDatasetGroups[i].release() );
+  }
+
+  QCOMPARE( 24, mpMeshLayer->datasetGroupCount() );
+
+  QgsMeshDatasetGroupTreeItem *rootItem = mpMeshLayer->datasetGroupTreeRootItem();
+
+  for ( int dsg = 0; dsg < 4; ++dsg )
+  {
+    QgsMeshDatasetGroupTreeItem *item = rootItem->childFromDatasetGroupIndex( 13 + dsg );
+    QCOMPARE( QString( "dataset_group_%1" ).arg( dsg ), item->name() );
+  }
+
+  for ( int dsg = 0; dsg < 3; ++dsg )
+    QCOMPARE( QString( "virtual_%1" ).arg( dsg ), rootItem->childFromDatasetGroupIndex( 17 + dsg )->name() );
+
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 13 )->groupIndexDependencies().count(), 4 ); // dataset_group_0
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 14 )->groupIndexDependencies().count(), 0 ); // dataset_group_1
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 15 )->groupIndexDependencies().count(), 0 ); // dataset_group_2
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 16 )->groupIndexDependencies().count(), 1 ); // dataset_group_3
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 17 )->groupIndexDependencies().count(), 3 ); // virtual_0
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 18 )->groupIndexDependencies().count(), 0 ); // virtual_1
+  QCOMPARE( rootItem->childFromDatasetGroupIndex( 19 )->groupIndexDependencies().count(), 0 ); // virtual_2
 }
 
 QGSTEST_MAIN( TestQgsMeshCalculator )


### PR DESCRIPTION
This PR introduces "on the fly" data set group for mesh layer.
With the mesh calculator the user can choose to create those "on the fly" dataset groups that will be added to the layer. Then, for this dataset group, the values are not stored in memory but calculated when needed whit the formula entered in the mesh calculator.

This new feature needs to introduce also a abstract QgsMeshDataGeneratorInterface class core API and a registry in the QgsApplication to store its derived class.
This mesh data generator is needed to create the "on the fly" dataset group in the mesh layer scope (when reading project), indeed "on-the-fly" dataset group class is defined in the analysis API.
This new mesh data generator could permit, in the future, to add new feature outside the core API but that could be used in the core through interface.