### PR TITLE
renderer usage for XYZ tile-based WMS layer and XYZ vector tile layer

### DIFF
--- a/src/3d/qgs3dmapsettings.cpp
+++ b/src/3d/qgs3dmapsettings.cpp
@@ -78,6 +78,7 @@ Qgs3DMapSettings::Qgs3DMapSettings( const Qgs3DMapSettings &other )
   , mDebugDepthMapCorner( other.mDebugDepthMapCorner )
   , mDebugDepthMapSize( other.mDebugDepthMapSize )
   , mTerrainRenderingEnabled( other.mTerrainRenderingEnabled )
+  , mRendererUsage( other.mRendererUsage )
 {
   for ( QgsAbstract3DRenderer *renderer : std::as_const( other.mRenderers ) )
   {
@@ -793,4 +794,14 @@ void Qgs3DMapSettings::setTerrainRenderingEnabled( bool terrainRenderingEnabled 
     return;
   mTerrainRenderingEnabled = terrainRenderingEnabled;
   emit terrainGeneratorChanged();
+}
+
+Qgis::RendererUsage Qgs3DMapSettings::rendererUsage() const
+{
+  return mRendererUsage;
+}
+
+void Qgs3DMapSettings::setRendererUsage( const Qgis::RendererUsage &renderingUsage )
+{
+  mRendererUsage = renderingUsage;
 }

--- a/src/3d/qgs3dmapsettings.h
+++ b/src/3d/qgs3dmapsettings.h
@@ -569,6 +569,22 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
      */
     void setTerrainRenderingEnabled( bool terrainRenderingEnabled );
 
+    /**
+     * Returns the rendering usage
+     *
+     * \see rendererUsage()
+     * \since QGIS 3.24
+     */
+    Qgis::RendererUsage rendererUsage() const;
+
+    /**
+     * Sets the rendering usage
+     *
+     * \see rendererUsage()
+     * \since QGIS 3.24
+     */
+    void setRendererUsage( const Qgis::RendererUsage &renderingUsage );
+
   signals:
     //! Emitted when the background color has changed
     void backgroundColorChanged();
@@ -786,6 +802,8 @@ class _3D_EXPORT Qgs3DMapSettings : public QObject, public QgsTemporalRangeObjec
     double mDebugDepthMapSize = 0.2;
 
     bool mTerrainRenderingEnabled = true;
+
+    Qgis::RendererUsage mRendererUsage;
 };
 
 

--- a/src/3d/qgslayoutitem3dmap.cpp
+++ b/src/3d/qgslayoutitem3dmap.cpp
@@ -132,6 +132,19 @@ void QgsLayoutItem3DMap::draw( QgsLayoutItemRenderContext &context )
   {
     painter->drawText( r, Qt::AlignCenter, tr( "Loading" ) );
     painter->restore();
+    if ( mSettings->rendererUsage() != Qgis::RendererUsage::View )
+    {
+      mSettings->setRendererUsage( Qgis::RendererUsage::View );
+      mEngine.reset(); //we need to rebuild the scene to force the render again
+    }
+  }
+  else
+  {
+    if ( mSettings->rendererUsage() != Qgis::RendererUsage::Export )
+    {
+      mSettings->setRendererUsage( Qgis::RendererUsage::Export );
+      mEngine.reset(); //we need to rebuild the scene to force the render again
+    }
   }
 
   QSizeF sizePixels = mLayout->renderContext().measurementConverter().convert( sizeWithUnits(), QgsUnitTypes::LayoutPixels ).toQSizeF();

--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -159,6 +159,7 @@ QgsMapSettings QgsTerrainTextureGenerator::baseMapSettings()
   mapSettings.setFlag( Qgis::MapSettingsFlag::Render3DMap );
   mapSettings.setTransformContext( mMap.transformContext() );
   mapSettings.setPathResolver( mMap.pathResolver() );
+  mapSettings.setRendererUsage( Qgis::RendererUsage::View );
 
   QgsMapThemeCollection *mapThemes = mMap.mapThemeCollection();
   QString mapThemeName = mMap.terrainMapTheme();

--- a/src/3d/terrain/qgsterraintexturegenerator_p.cpp
+++ b/src/3d/terrain/qgsterraintexturegenerator_p.cpp
@@ -159,7 +159,7 @@ QgsMapSettings QgsTerrainTextureGenerator::baseMapSettings()
   mapSettings.setFlag( Qgis::MapSettingsFlag::Render3DMap );
   mapSettings.setTransformContext( mMap.transformContext() );
   mapSettings.setPathResolver( mMap.pathResolver() );
-  mapSettings.setRendererUsage( Qgis::RendererUsage::View );
+  mapSettings.setRendererUsage( mMap.rendererUsage() );
 
   QgsMapThemeCollection *mapThemes = mMap.mapThemeCollection();
   QString mapThemeName = mMap.terrainMapTheme();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -13851,6 +13851,7 @@ void QgisApp::new3DMapCanvas()
     // new scenes default to a single directional light
     map->setDirectionalLights( QList<QgsDirectionalLightSettings>() << QgsDirectionalLightSettings() );
     map->setOutputDpi( QgsApplication::desktop()->logicalDpiX() );
+    map->setRendererUsage( Qgis::RendererUsage::View );
 
     dock->setMapSettings( map );
 

--- a/src/core/layout/qgslayoutitemmap.cpp
+++ b/src/core/layout/qgslayoutitemmap.cpp
@@ -1519,11 +1519,13 @@ QgsMapSettings QgsLayoutItemMap::mapSettings( const QgsRectangle &extent, QSizeF
     //if outputting layout, we disable optimisations like layer simplification by default, UNLESS the context specifically tells us to use them
     jobMapSettings.setFlag( Qgis::MapSettingsFlag::UseRenderingOptimization, mLayout->renderContext().simplifyMethod().simplifyHints() != QgsVectorSimplifyMethod::NoSimplification );
     jobMapSettings.setSimplifyMethod( mLayout->renderContext().simplifyMethod() );
+    jobMapSettings.setRendererUsage( Qgis::RendererUsage::Export );
   }
   else
   {
     // preview render - always use optimization
     jobMapSettings.setFlag( Qgis::MapSettingsFlag::UseRenderingOptimization, true );
+    jobMapSettings.setRendererUsage( Qgis::RendererUsage::View );
   }
 
   jobMapSettings.setExpressionContext( expressionContext );

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -1251,6 +1251,22 @@ class CORE_EXPORT Qgis
     Q_ENUM( AngularDirection )
 
     /**
+     *  Usage of the renderer.
+     *
+     *  \note This usage not alter how the map gets rendered but the intention is that data provider
+     *  know the context of rendering and may report that to the backend.
+     *
+     * \since QGIS 3.24
+     */
+    enum class RendererUsage : int
+    {
+      View, //!< Renderer used for displaying on screen
+      Export, //!< Renderer used for printing or exporting to a file
+      Unknown, //!< Renderer used for unknown usage
+    };
+    Q_ENUM( RendererUsage )
+
+    /**
      * History provider backends.
      *
      * \since QGIS 3.24

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -854,3 +854,13 @@ void QgsMapSettings::setZRange( const QgsDoubleRange &zRange )
 {
   mZRange = zRange;
 }
+
+Qgis::RendererUsage QgsMapSettings::rendererUsage() const
+{
+    return mRendererUsage;
+}
+
+void QgsMapSettings::setRendererUsage(const Qgis::RendererUsage &rendererUsage)
+{
+    mRendererUsage = rendererUsage;
+}

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -805,6 +805,22 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
      */
     void setZRange( const QgsDoubleRange &range );
 
+    /**
+     * Returns the rendering usage
+     *
+     * \see setRendererUsage()
+     * \since QGIS 3.24
+     */
+    Qgis::RendererUsage rendererUsage() const;
+
+    /**
+     * Sets the rendering usage
+     *
+     * \see rendererUsage()
+     * \since QGIS 3.24
+     */
+    void setRendererUsage( const Qgis::RendererUsage &rendererUsage );
+
   protected:
 
     double mDpi = 96.0;
@@ -863,6 +879,8 @@ class CORE_EXPORT QgsMapSettings : public QgsTemporalRangeObject
     QgsGeometry mLabelBoundaryGeometry;
 
     QgsVectorSimplifyMethod mSimplifyMethod;
+
+    Qgis::RendererUsage mRendererUsage = Qgis::RendererUsage::Unknown;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -78,6 +78,7 @@ QgsRenderContext::QgsRenderContext( const QgsRenderContext &rh )
   , mSize( rh.mSize )
   , mDevicePixelRatio( rh.mDevicePixelRatio )
   , mImageFormat( rh.mImageFormat )
+  , mRendererUsage( rh.mRendererUsage )
 #ifdef QGISDEBUG
   , mHasTransformContext( rh.mHasTransformContext )
 #endif
@@ -123,6 +124,7 @@ QgsRenderContext &QgsRenderContext::operator=( const QgsRenderContext &rh )
   mDevicePixelRatio = rh.mDevicePixelRatio;
   mImageFormat = rh.mImageFormat;
   setIsTemporal( rh.isTemporal() );
+  mRendererUsage = rh.mRendererUsage;
   if ( isTemporal() )
     setTemporalRange( rh.temporalRange() );
 #ifdef QGISDEBUG
@@ -276,6 +278,8 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings &mapSet
   ctx.setImageFormat( mapSettings.outputImageFormat() );
 
   ctx.mClippingRegions = mapSettings.clippingRegions();
+
+  ctx.mRendererUsage = mapSettings.rendererUsage();
 
   return ctx;
 }

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -974,6 +974,22 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
      */
     QImage::Format imageFormat() const { return mImageFormat; }
 
+    /**
+    * Returns the renderer usage
+    *
+    * \see setRendererUsage()
+    * \since QGIS 3.24
+    */
+    Qgis::RendererUsage rendererUsage() const {return mRendererUsage;}
+
+    /**
+    * Sets the renderer usage
+    *
+    * \see rendererUsage()
+    * \since QGIS 3.24
+    */
+    void setRendererUsage( Qgis::RendererUsage usage ) {mRendererUsage = usage;}
+
   private:
 
     Qgis::RenderContextFlags mFlags;
@@ -1086,6 +1102,8 @@ class CORE_EXPORT QgsRenderContext : public QgsTemporalRangeObject
     QSize mSize;
     float mDevicePixelRatio = 1.0;
     QImage::Format mImageFormat = QImage::Format_ARGB32_Premultiplied;
+
+    Qgis::RendererUsage mRendererUsage = Qgis::RendererUsage::Unknown;
 
 #ifdef QGISDEBUG
     bool mHasTransformContext = false;

--- a/src/core/raster/qgsrasterinterface.cpp
+++ b/src/core/raster/qgsrasterinterface.cpp
@@ -643,3 +643,13 @@ QString QgsRasterInterface::displayBandName( int bandNumber ) const
   }
   return name;
 }
+
+Qgis::RendererUsage QgsRasterBlockFeedback::rendererUsage() const
+{
+    return mRendererUsage;
+}
+
+void QgsRasterBlockFeedback::setRendererUsage(const Qgis::RendererUsage &rendererUsage)
+{
+    mRendererUsage = rendererUsage;
+}

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -93,6 +93,22 @@ class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
      */
     QStringList errors() const { return mErrors; }
 
+    /**
+     * Returns the renderer usage of the associated block reading reading
+     *
+     * \see setRendererUsage()
+     * \since QGIS 3.24.0
+     */
+    Qgis::RendererUsage rendererUsage() const;
+
+    /**
+     * Sets the renderer usage of the associated block reading reading
+     *
+     * \see rendererUsage()
+     * \since QGIS 3.24.0
+     */
+    void setRendererUsage( const Qgis::RendererUsage &rendererUsage );
+
   private:
 
     /**
@@ -106,6 +122,8 @@ class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 
     //! List of errors encountered while retrieving block
     QStringList mErrors;
+
+    Qgis::RendererUsage mRendererUsage = Qgis::RendererUsage::Unknown;
 };
 
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -282,6 +282,8 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer *layer, QgsRender
   }
 
   mClippingRegions = QgsMapClippingUtils::collectClippingRegionsForLayer( *renderContext(), layer );
+
+  mFeedback->setRendererUsage( rendererContext.rendererUsage() );
 }
 
 QgsRasterLayerRenderer::~QgsRasterLayerRenderer()

--- a/src/core/vectortile/qgsvectortilelayerrenderer.cpp
+++ b/src/core/vectortile/qgsvectortilelayerrenderer.cpp
@@ -107,6 +107,22 @@ bool QgsVectorTileLayerRenderer::render()
 
   const bool isAsync = ( mSourceType == QLatin1String( "xyz" ) );
 
+  if ( mSourceType == QLatin1String( "xyz" ) && mSourcePath.contains( QLatin1String( "{usage}" ) ) )
+  {
+    switch ( renderContext()->rendererUsage() )
+    {
+      case Qgis::RendererUsage::View:
+        mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
+        break;
+      case Qgis::RendererUsage::Export:
+        mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
+        break;
+      case Qgis::RendererUsage::Unknown:
+        mSourcePath.replace( QLatin1String( "{usage}" ), QLatin1String( "unknown" ) );
+        break;
+    }
+  }
+
   std::unique_ptr<QgsVectorTileLoader> asyncLoader;
   QList<QgsVectorTileRawData> rawTiles;
   if ( !isAsync )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -209,6 +209,8 @@ QgsMapCanvas::QgsMapCanvas( QWidget *parent )
   QSize s = viewport()->size();
   mSettings.setOutputSize( s );
 
+  mSettings.setRendererUsage( Qgis::RendererUsage::View );
+
   setSceneRect( 0, 0, s.width(), s.height() );
   mScene->setSceneRect( QRectF( 0, 0, s.width(), s.height() ) );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -584,7 +584,14 @@ static bool _fuzzyContainsRect( const QRectF &r1, const QRectF &r2 )
   return r1.contains( r2.adjusted( epsilon, epsilon, -epsilon, -epsilon ) );
 }
 
-void QgsWmsProvider::fetchOtherResTiles( QgsTileMode tileMode, const QgsRectangle &viewExtent, int imageWidth, QList<QRectF> &missingRects, double tres, int resOffset, QList<TileImage> &otherResTiles )
+void QgsWmsProvider::fetchOtherResTiles( QgsTileMode tileMode,
+    const QgsRectangle &viewExtent,
+    int imageWidth,
+    QList<QRectF> &missingRects,
+    double tres,
+    int resOffset,
+    QList<TileImage> &otherResTiles,
+    QgsRasterBlockFeedback *feedback )
 {
   if ( !mTileMatrixSet )
     return;  // there is no tile matrix set defined for ordinary WMS (with user-specified tile size)
@@ -623,7 +630,7 @@ void QgsWmsProvider::fetchOtherResTiles( QgsTileMode tileMode, const QgsRectangl
       break;
 
     case XYZ:
-      createTileRequestsXYZ( tmOther, tiles, requests );
+      createTileRequestsXYZ( tmOther, tiles, requests, feedback );
       break;
   }
 
@@ -839,7 +846,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
         break;
 
       case XYZ:
-        createTileRequestsXYZ( tm, tiles, requests );
+        createTileRequestsXYZ( tm, tiles, requests, feedback );
         break;
 
       default:
@@ -1364,7 +1371,7 @@ static QString _tile2quadkey( int tileX, int tileY, int z )
 }
 
 
-void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const QgsWmsProvider::TilePositions &tiles, QgsWmsProvider::TileRequests &requests )
+void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const QgsWmsProvider::TilePositions &tiles, QgsWmsProvider::TileRequests &requests, QgsRasterBlockFeedback *feedback )
 {
   int z = tm->identifier.toInt();
   QString url = mSettings.mBaseUrl;
@@ -1389,6 +1396,22 @@ void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const Q
       turl.replace( QLatin1String( "{y}" ), QString::number( tile.row ), Qt::CaseInsensitive );
     }
     turl.replace( QLatin1String( "{z}" ), QString::number( z ), Qt::CaseInsensitive );
+
+    if ( turl.contains( QLatin1String( "{usage}" ) ) && feedback )
+    {
+      switch ( feedback->rendererUsage() )
+      {
+        case Qgis::RendererUsage::View:
+          turl.replace( QLatin1String( "{usage}" ), QLatin1String( "view" ) );
+          break;
+        case Qgis::RendererUsage::Export:
+          turl.replace( QLatin1String( "{usage}" ), QLatin1String( "export" ) );
+          break;
+        case Qgis::RendererUsage::Unknown:
+          turl.replace( QLatin1String( "{usage}" ), QLatin1String( "unknown" ) );
+          break;
+      }
+    }
 
     QgsDebugMsgLevel( QStringLiteral( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ), 2 );
     requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -344,7 +344,7 @@ class QgsWmsProvider final: public QgsRasterDataProvider
     QUrl createRequestUrlWMS( const QgsRectangle &viewExtent, int pixelWidth, int pixelHeight );
     void createTileRequestsWMSC( const QgsWmtsTileMatrix *tm, const QgsWmsProvider::TilePositions &tiles, QgsWmsProvider::TileRequests &requests );
     void createTileRequestsWMTS( const QgsWmtsTileMatrix *tm, const QgsWmsProvider::TilePositions &tiles, QgsWmsProvider::TileRequests &requests );
-    void createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const QgsWmsProvider::TilePositions &tiles, QgsWmsProvider::TileRequests &requests );
+    void createTileRequestsXYZ( const QgsWmtsTileMatrix *tm, const QgsWmsProvider::TilePositions &tiles, QgsWmsProvider::TileRequests &requests, QgsRasterBlockFeedback *feedback = nullptr );
 
     /**
       * Add WMS-T parameters to the \a query, if provider has temporal properties
@@ -362,7 +362,7 @@ class QgsWmsProvider final: public QgsRasterDataProvider
       bool smooth; //!< Whether to use antialiasing/smooth transforms when rendering tile
     } TileImage;
     //! Gets tiles from a different resolution to cover the missing areas
-    void fetchOtherResTiles( QgsTileMode tileMode, const QgsRectangle &viewExtent, int imageWidth, QList<QRectF> &missing, double tres, int resOffset, QList<TileImage> &otherResTiles );
+    void fetchOtherResTiles( QgsTileMode tileMode, const QgsRectangle &viewExtent, int imageWidth, QList<QRectF> &missing, double tres, int resOffset, QList<TileImage> &otherResTiles, QgsRasterBlockFeedback *feedback = nullptr );
 
     /**
      * Returns the full url to request legend graphic


### PR DESCRIPTION
This PR introduces the `RendererUsage` enum that allows to propagate the usage of the rendering through the map layer renderer and to the data provider. 

Here, this usage is used for XYZ WMS data provider and XYZ vector tile loader to specify the usage of the request.

